### PR TITLE
Add /mobile route group and sample MobileMatches endpoints

### DIFF
--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -35,6 +35,7 @@ using Tycoon.Backend.Api.Features.Leaderboards;
 using Tycoon.Backend.Api.Features.Matches;
 using Tycoon.Backend.Api.Features.Matchmaking;
 using Tycoon.Backend.Api.Features.Missions;
+using Tycoon.Backend.Api.Features.Mobile.Matches;
 using Tycoon.Backend.Api.Features.Party;
 using Tycoon.Backend.Api.Features.Players;
 using Tycoon.Backend.Api.Features.Powerups;
@@ -505,6 +506,10 @@ FriendsEndpoints.Map(app);
 PartyEndpoints.Map(app);
 RankedLeaderboardsEndpoints.Map(app);
 SeasonRewardsEndpoints.Map(app);
+
+// Mobile endpoints (separate route surface for mobile-specific contracts/workflows)
+var mobile = app.MapGroup("/mobile").WithTags("Mobile").WithOpenApi();
+MobileMatchesEndpoints.Map(mobile);
 
 // Admin endpoints
 var admin = app.MapGroup("/admin").RequireAdminOpsKey();


### PR DESCRIPTION
### Motivation
- Provide a dedicated transport surface for mobile-specific contracts and workflows so mobile DTOs, defaults, and rate limits can diverge without changing the primary REST surface. 
- Scaffold a minimal, parity-preserving mobile matches implementation that reuses existing application services and MediatR handlers to avoid duplicating business logic.

### Description
- Added a `/mobile` route group in `Program.cs` and wired `MobileMatchesEndpoints.Map(mobile)` to expose mobile-specific routes. 
- Introduced `Tycoon.Backend.Api/Features/Mobile/Matches/MobileMatchesEndpoints.cs` with sample endpoints `POST /mobile/matches/start` and `POST /mobile/matches/submit`. 
- Implemented request guards using `EnforcementService` and `ModerationService`, forwarded commands to MediatR (`StartMatch`, `SubmitMatch`), and applied the existing rate-limit policy (`matches-submit`).

### Testing
- Attempted an automated build with `dotnet build Tycoon.Backend.Api/Tycoon.Backend.Api.csproj -v minimal`, which failed in this environment because `dotnet` is not installed (build could not be executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998cc458db8832d919afe70d9e00005)