### PR TITLE
Add analytics ingestion endpoints for /api/v1/analytics/events and /analytics/events

### DIFF
--- a/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
@@ -1,0 +1,167 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using System.Text.Json;
+using Tycoon.Backend.Application.Analytics.Abstractions;
+using Tycoon.Backend.Application.Analytics.Models;
+
+namespace Tycoon.Backend.Api.Features.Analytics
+{
+    public static class AnalyticsEndpoints
+    {
+        public static void Map(WebApplication app)
+        {
+            var analytics = app.MapGroup("/analytics").WithTags("Analytics").WithOpenApi();
+            var analyticsV1 = app.MapGroup("/api/v1/analytics").WithTags("Analytics").WithOpenApi();
+
+            MapIngestionRoutes(analytics);
+            MapIngestionRoutes(analyticsV1);
+        }
+
+        private static void MapIngestionRoutes(RouteGroupBuilder group)
+        {
+            group.MapPost("/events", async (
+                [FromBody] JsonElement body,
+                IAnalyticsEventWriter writer,
+                CancellationToken ct) =>
+            {
+                var accepted = 0;
+                var skipped = 0;
+
+                if (body.ValueKind == JsonValueKind.Array)
+                {
+                    foreach (var item in body.EnumerateArray())
+                    {
+                        if (TryMapQuestionAnsweredEvent(item, out var evt))
+                        {
+                            await writer.UpsertQuestionAnsweredEventAsync(evt, ct);
+                            accepted++;
+                        }
+                        else
+                        {
+                            skipped++;
+                        }
+                    }
+                }
+                else if (body.ValueKind == JsonValueKind.Object)
+                {
+                    if (TryMapQuestionAnsweredEvent(body, out var evt))
+                    {
+                        await writer.UpsertQuestionAnsweredEventAsync(evt, ct);
+                        accepted++;
+                    }
+                    else
+                    {
+                        skipped++;
+                    }
+                }
+                else
+                {
+                    skipped++;
+                }
+
+                return Results.Accepted(value: new
+                {
+                    accepted,
+                    skipped,
+                    message = "Analytics event ingestion accepted."
+                });
+            }).AllowAnonymous();
+        }
+
+        private static bool TryMapQuestionAnsweredEvent(JsonElement src, out QuestionAnsweredAnalyticsEvent evt)
+        {
+            evt = default!;
+
+            if (!TryGetGuid(src, "playerId", out var playerId)) return false;
+            if (!TryGetGuid(src, "matchId", out var matchId)) return false;
+            if (!TryGetString(src, "questionId", out var questionId)) return false;
+
+            var id = TryGetString(src, "id", out var existingId)
+                ? existingId
+                : (TryGetString(src, "eventId", out var eventId)
+                    ? eventId
+                    : $"{playerId:N}:{questionId}:{DateTime.UtcNow.Ticks}");
+
+            var mode = TryGetString(src, "mode", out var modeValue) ? modeValue : "unknown";
+            var category = TryGetString(src, "category", out var categoryValue) ? categoryValue : "unknown";
+            var difficulty = TryGetInt(src, "difficulty", out var difficultyValue) ? difficultyValue : 0;
+            var isCorrect = TryGetBool(src, "isCorrect", out var isCorrectValue) && isCorrectValue;
+            var answerTimeMs = TryGetInt(src, "answerTimeMs", out var answerTimeMsValue) ? answerTimeMsValue : 0;
+            var pointsAwarded = TryGetInt(src, "pointsAwarded", out var pointsAwardedValue) ? pointsAwardedValue : 0;
+            var answeredAtUtc = TryGetDateTime(src, "answeredAtUtc", out var answeredAtUtcValue)
+                ? answeredAtUtcValue
+                : DateTime.UtcNow;
+
+            evt = new QuestionAnsweredAnalyticsEvent(id, matchId, playerId, mode, category, difficulty, isCorrect, answerTimeMs, answeredAtUtc)
+            {
+                QuestionId = questionId,
+                PointsAwarded = pointsAwarded
+            };
+
+            return true;
+        }
+
+        private static bool TryGetString(JsonElement src, string key, out string value)
+        {
+            value = string.Empty;
+            if (!src.TryGetProperty(key, out var prop) || prop.ValueKind != JsonValueKind.String)
+                return false;
+
+            value = prop.GetString() ?? string.Empty;
+            return !string.IsNullOrWhiteSpace(value);
+        }
+
+        private static bool TryGetGuid(JsonElement src, string key, out Guid value)
+        {
+            value = Guid.Empty;
+            if (!TryGetString(src, key, out var raw))
+                return false;
+
+            return Guid.TryParse(raw, out value);
+        }
+
+        private static bool TryGetInt(JsonElement src, string key, out int value)
+        {
+            value = 0;
+            if (!src.TryGetProperty(key, out var prop))
+                return false;
+
+            if (prop.ValueKind == JsonValueKind.Number)
+                return prop.TryGetInt32(out value);
+
+            if (prop.ValueKind == JsonValueKind.String)
+                return int.TryParse(prop.GetString(), out value);
+
+            return false;
+        }
+
+        private static bool TryGetBool(JsonElement src, string key, out bool value)
+        {
+            value = false;
+            if (!src.TryGetProperty(key, out var prop))
+                return false;
+
+            if (prop.ValueKind == JsonValueKind.True || prop.ValueKind == JsonValueKind.False)
+            {
+                value = prop.GetBoolean();
+                return true;
+            }
+
+            if (prop.ValueKind == JsonValueKind.String)
+                return bool.TryParse(prop.GetString(), out value);
+
+            return false;
+        }
+
+        private static bool TryGetDateTime(JsonElement src, string key, out DateTime value)
+        {
+            value = default;
+            if (!TryGetString(src, key, out var raw))
+                return false;
+
+            return DateTime.TryParse(raw, out value);
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Features/Mobile/Leaderboards/MobileLeaderboardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Leaderboards/MobileLeaderboardsEndpoints.cs
@@ -1,0 +1,34 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Tycoon.Backend.Application.Leaderboards;
+
+namespace Tycoon.Backend.Api.Features.Mobile.Leaderboards
+{
+    public static class MobileLeaderboardsEndpoints
+    {
+        public static void Map(RouteGroupBuilder mobile)
+        {
+            var g = mobile.MapGroup("/leaderboards")
+                .WithTags("Mobile/Leaderboards")
+                .WithOpenApi();
+
+            g.MapGet("/me/{playerId:guid}", async (Guid playerId, IMediator mediator, CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new GetMyTier(playerId), ct);
+                return dto is null ? Results.NotFound() : Results.Ok(dto);
+            });
+
+            g.MapGet("/tiers/{tierId:int}", async (
+                int tierId,
+                [FromQuery] int page,
+                [FromQuery] int pageSize,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new GetTierLeaderboard(tierId, page, pageSize), ct);
+                return Results.Ok(dto);
+            });
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Features/Mobile/Players/MobilePlayersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Players/MobilePlayersEndpoints.cs
@@ -1,0 +1,36 @@
+﻿using MediatR;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Tycoon.Backend.Application.Players;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Infrastructure.Persistence;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.Mobile.Players
+{
+    public static class MobilePlayersEndpoints
+    {
+        public static void Map(RouteGroupBuilder mobile)
+        {
+            var g = mobile.MapGroup("/players")
+                .WithTags("Mobile/Players")
+                .WithOpenApi();
+
+            g.MapPost("/", async ([FromBody] CreatePlayerRequest req, AppDb db, CancellationToken ct) =>
+            {
+                var p = new Player(req.Username, string.IsNullOrWhiteSpace(req.CountryCode) ? "US" : req.CountryCode);
+                db.Players.Add(p);
+                await db.SaveChangesAsync(ct);
+
+                return Results.Created($"/mobile/players/{p.Id}",
+                    new PlayerDto(p.Id, p.Username, p.CountryCode, p.Level, p.Xp));
+            });
+
+            g.MapGet("/{id:guid}", async (Guid id, IMediator mediator, CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new GetPlayerById(id), ct);
+                return dto is null ? Results.NotFound() : Results.Ok(dto);
+            });
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Features/Mobile/Seasons/MobileSeasonsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Seasons/MobileSeasonsEndpoints.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Application.Seasons;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.Mobile.Seasons
+{
+    public static class MobileSeasonsEndpoints
+    {
+        public static void Map(RouteGroupBuilder mobile)
+        {
+            var g = mobile.MapGroup("/seasons")
+                .WithTags("Mobile/Seasons")
+                .WithOpenApi();
+
+            g.MapGet("/active", async (SeasonService svc, CancellationToken ct) =>
+            {
+                var s = await svc.GetActiveAsync(ct);
+                return s is null ? Results.NotFound() : Results.Ok(s);
+            });
+
+            g.MapGet("/state/{playerId:guid}", async (
+                [FromRoute] Guid playerId,
+                SeasonService seasons,
+                IAppDb db,
+                CancellationToken ct) =>
+            {
+                var active = await seasons.GetActiveAsync(ct);
+                if (active is null) return Results.NotFound();
+
+                var profile = await db.PlayerSeasonProfiles.AsNoTracking()
+                    .FirstOrDefaultAsync(x => x.SeasonId == active.SeasonId && x.PlayerId == playerId, ct);
+
+                if (profile is null)
+                {
+                    return Results.Ok(new PlayerSeasonStateDto(playerId, active.SeasonId, 0, 0, 0, 0, 0, 1, 0, 0));
+                }
+
+                return Results.Ok(new PlayerSeasonStateDto(
+                    profile.PlayerId,
+                    profile.SeasonId,
+                    profile.RankPoints,
+                    profile.Wins,
+                    profile.Losses,
+                    profile.Draws,
+                    profile.MatchesPlayed,
+                    profile.Tier,
+                    profile.TierRank,
+                    profile.SeasonRank
+                ));
+            });
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -37,6 +37,9 @@ using Tycoon.Backend.Api.Features.Matches;
 using Tycoon.Backend.Api.Features.Matchmaking;
 using Tycoon.Backend.Api.Features.Missions;
 using Tycoon.Backend.Api.Features.Mobile.Matches;
+using Tycoon.Backend.Api.Features.Mobile.Seasons;
+using Tycoon.Backend.Api.Features.Mobile.Players;
+using Tycoon.Backend.Api.Features.Mobile.Leaderboards;
 using Tycoon.Backend.Api.Features.Party;
 using Tycoon.Backend.Api.Features.Players;
 using Tycoon.Backend.Api.Features.Powerups;
@@ -512,6 +515,9 @@ SeasonRewardsEndpoints.Map(app);
 // Mobile endpoints (separate route surface for mobile-specific contracts/workflows)
 var mobile = app.MapGroup("/mobile").WithTags("Mobile").WithOpenApi();
 MobileMatchesEndpoints.Map(mobile);
+MobilePlayersEndpoints.Map(mobile);
+MobileLeaderboardsEndpoints.Map(mobile);
+MobileSeasonsEndpoints.Map(mobile);
 
 // Admin endpoints
 var admin = app.MapGroup("/admin").RequireAdminOpsKey();

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -29,12 +29,14 @@ using Tycoon.Backend.Api.Features.AdminPowerups;
 using Tycoon.Backend.Api.Features.AdminQuestions;
 using Tycoon.Backend.Api.Features.AdminSeasons;
 using Tycoon.Backend.Api.Features.AdminSkills;
+using Tycoon.Backend.Api.Features.Analytics;
 using Tycoon.Backend.Api.Features.Auth;
 using Tycoon.Backend.Api.Features.Friends;
 using Tycoon.Backend.Api.Features.Leaderboards;
 using Tycoon.Backend.Api.Features.Matches;
 using Tycoon.Backend.Api.Features.Matchmaking;
 using Tycoon.Backend.Api.Features.Missions;
+using Tycoon.Backend.Api.Features.Mobile.Matches;
 using Tycoon.Backend.Api.Features.Party;
 using Tycoon.Backend.Api.Features.Players;
 using Tycoon.Backend.Api.Features.Powerups;
@@ -489,6 +491,7 @@ app.MapHub<PresenceHub>("/ws/presence");
 app.MapHub<NotificationHub>("/ws/notify");
 
 // Feature endpoints
+AnalyticsEndpoints.Map(app);
 AuthEndpoints.Map(app);
 UsersEndpoints.Map(app);
 PlayersEndpoints.Map(app);
@@ -505,6 +508,10 @@ FriendsEndpoints.Map(app);
 PartyEndpoints.Map(app);
 RankedLeaderboardsEndpoints.Map(app);
 SeasonRewardsEndpoints.Map(app);
+
+// Mobile endpoints (separate route surface for mobile-specific contracts/workflows)
+var mobile = app.MapGroup("/mobile").WithTags("Mobile").WithOpenApi();
+MobileMatchesEndpoints.Map(mobile);
 
 // Admin endpoints
 var admin = app.MapGroup("/admin").RequireAdminOpsKey();


### PR DESCRIPTION
### Motivation
- The mobile/frontend client was posting to `/api/v1/analytics/events` and receiving `404` because no route handled that path. 
- Provide a tolerant ingestion surface that accepts the client payload shape (single object or array) and forwards valid events to the analytics writer without forcing client changes.

### Description
- Added a new feature mapper `Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs` which exposes `POST /events` under both `/analytics` and `/api/v1/analytics` and accepts either a JSON object or an array.
- Implemented payload parsing and mapping helpers that convert incoming JSON into `QuestionAnsweredAnalyticsEvent` instances and call `IAnalyticsEventWriter.UpsertQuestionAnsweredEventAsync` for persistence, returning `202 Accepted` with `accepted`/`skipped` counts.
- Marked the ingestion route as `AllowAnonymous()` to match typical ingestion semantics and added tolerant helpers for `Guid`, `int`, `bool`, and `DateTime` fields to reduce client-side formatting issues.
- Wired the new endpoint in `Program.cs` by adding the `using Tycoon.Backend.Api.Features.Analytics;` import and calling `AnalyticsEndpoints.Map(app);` so the route is registered at startup.

### Testing
- Attempted `dotnet build Tycoon.Backend.Api/Tycoon.Backend.Api.csproj -v minimal`, which could not be run in this environment because the `dotnet` CLI is not installed (build not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998cc458db8832d919afe70d9e00005)