### PR TITLE
Fix Docker migration bootstrapping and anti-cheat schema baseline handling

### DIFF
--- a/Tycoon.Backend.Domain/Entities/AntiCheatFlag.cs
+++ b/Tycoon.Backend.Domain/Entities/AntiCheatFlag.cs
@@ -57,7 +57,7 @@ namespace Tycoon.Backend.Domain.Entities
             Action = action;
             Message = message;
             EvidenceJson = evidenceJson;
-            CreatedAtUtc = DateTimeOffset.UtcNow;
+            CreatedAtUtc = createdAtUtc;
         }
         public static AntiCheatFlag LeaderLeftPartyDuringMatch(
             Guid playerId,
@@ -77,7 +77,7 @@ namespace Tycoon.Backend.Domain.Entities
                 severity: AntiCheatSeverity.Warning,
                 action: AntiCheatAction.Warn,
                 message: $"Leader left party {partyId} during active match.",
-                evidenceJson: null,
+                evidenceJson: evidence,
                 createdAtUtc: DateTimeOffset.UtcNow
             );
         }

--- a/Tycoon.Backend.Migrations/Migrations/20260217200552_InitialCreate.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260217200552_InitialCreate.cs
@@ -11,27 +11,23 @@ namespace Tycoon.Backend.Migrations.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.CreateTable(
-                name: "anti_cheat_flags",
-                columns: table => new
-                {
-                    Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    MatchId = table.Column<Guid>(type: "uuid", nullable: false),
-                    PlayerId = table.Column<Guid>(type: "uuid", nullable: true),
-                    RuleKey = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
-                    Severity = table.Column<int>(type: "integer", nullable: false),
-                    Action = table.Column<int>(type: "integer", nullable: false),
-                    Message = table.Column<string>(type: "character varying(300)", maxLength: 300, nullable: false),
-                    EvidenceJson = table.Column<string>(type: "text", nullable: true),
-                    CreatedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
-                    ReviewedAtUtc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
-                    ReviewedBy = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
-                    ReviewNote = table.Column<string>(type: "character varying(400)", maxLength: 400, nullable: true)
-                },
-                constraints: table =>
-                {
-                    table.PrimaryKey("PK_anti_cheat_flags", x => x.Id);
-                });
+            migrationBuilder.Sql(@"""
+                CREATE TABLE IF NOT EXISTS anti_cheat_flags (
+                    "Id" uuid NOT NULL,
+                    "MatchId" uuid NOT NULL,
+                    "PlayerId" uuid,
+                    "RuleKey" character varying(64) NOT NULL,
+                    "Severity" integer NOT NULL,
+                    "Action" integer NOT NULL,
+                    "Message" character varying(300) NOT NULL,
+                    "EvidenceJson" text,
+                    "CreatedAtUtc" timestamp with time zone NOT NULL,
+                    "ReviewedAtUtc" timestamp with time zone,
+                    "ReviewedBy" character varying(64),
+                    "ReviewNote" character varying(400),
+                    CONSTRAINT "PK_anti_cheat_flags" PRIMARY KEY ("Id")
+                );
+                """);
 
             migrationBuilder.CreateTable(
                 name: "economy_transactions",
@@ -823,35 +819,35 @@ namespace Tycoon.Backend.Migrations.Migrations
                         onDelete: ReferentialAction.Cascade);
                 });
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_CreatedAtUtc",
-                table: "anti_cheat_flags",
-                column: "CreatedAtUtc");
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_CreatedAtUtc"
+                    ON anti_cheat_flags ("CreatedAtUtc");
+                """);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_MatchId",
-                table: "anti_cheat_flags",
-                column: "MatchId");
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_MatchId"
+                    ON anti_cheat_flags ("MatchId");
+                """);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_PlayerId",
-                table: "anti_cheat_flags",
-                column: "PlayerId");
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_PlayerId"
+                    ON anti_cheat_flags ("PlayerId");
+                """);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_ReviewedAtUtc",
-                table: "anti_cheat_flags",
-                column: "ReviewedAtUtc");
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_ReviewedAtUtc"
+                    ON anti_cheat_flags ("ReviewedAtUtc");
+                """);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_Severity_CreatedAtUtc",
-                table: "anti_cheat_flags",
-                columns: new[] { "Severity", "CreatedAtUtc" });
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_Severity_CreatedAtUtc"
+                    ON anti_cheat_flags ("Severity", "CreatedAtUtc");
+                """);
 
-            migrationBuilder.CreateIndex(
-                name: "IX_anti_cheat_flags_Severity_ReviewedAtUtc_CreatedAtUtc",
-                table: "anti_cheat_flags",
-                columns: new[] { "Severity", "ReviewedAtUtc", "CreatedAtUtc" });
+            migrationBuilder.Sql(@"""
+                CREATE INDEX IF NOT EXISTS "IX_anti_cheat_flags_Severity_ReviewedAtUtc_CreatedAtUtc"
+                    ON anti_cheat_flags ("Severity", "ReviewedAtUtc", "CreatedAtUtc");
+                """);
 
             migrationBuilder.CreateIndex(
                 name: "IX_economy_transaction_lines_EconomyTransactionId",

--- a/Tycoon.MigrationService/MigrationWorker.cs
+++ b/Tycoon.MigrationService/MigrationWorker.cs
@@ -121,9 +121,17 @@ public sealed class MigrationWorker : BackgroundService
                     _log.Information("Detected {MigrationsCount} migrations in assembly {MigrationsAssembly}.",
                         migrationsCount, migrationsAssembly.Assembly.GetName().Name);
 
-                    _log.Information("Applying EF migrations…");
-                    await db.Database.MigrateAsync(stoppingToken);
-                    _log.Information("EF migrations completed successfully");
+                    var recoveredFromSchemaDrift = await TryBaselineOrRepairFromPreExistingSchemaAsync(
+                        db,
+                        autoRepairOnMissingTables,
+                        stoppingToken);
+
+                    if (!recoveredFromSchemaDrift)
+                    {
+                        _log.Information("Applying EF migrations…");
+                        await db.Database.MigrateAsync(stoppingToken);
+                        _log.Information("EF migrations completed successfully");
+                    }
                 }
 
                 await EnsureCriticalTablesReadyAsync(db, autoRepairOnMissingTables, stoppingToken);
@@ -187,6 +195,146 @@ public sealed class MigrationWorker : BackgroundService
         finally
         {
             _lifetime.StopApplication();
+        }
+    }
+
+    private async Task<bool> TryBaselineOrRepairFromPreExistingSchemaAsync(
+        AppDb db,
+        bool autoRepairOnMissingTables,
+        CancellationToken ct)
+    {
+        var appliedMigrations = await db.Database.GetAppliedMigrationsAsync(ct);
+        if (appliedMigrations.Any())
+            return false;
+
+        // Sentinel check: if key legacy/app tables exist while EF history is empty,
+        // initial migration is likely to fail with "relation already exists".
+        var sentinelTables = new[] { "anti_cheat_flags", "users", "matches", "Missions", "Tiers" };
+        var existingSentinels = new List<string>();
+
+        foreach (var table in sentinelTables)
+        {
+            if (await TableExistsAsync(db, table, ct))
+                existingSentinels.Add(table);
+        }
+
+        if (existingSentinels.Count == 0)
+            return false;
+
+        _log.Warning(
+            "Detected pre-existing tables ({Tables}) while __EFMigrationsHistory is empty. " +
+            "This indicates schema/history drift and can cause initial migration conflicts.",
+            string.Join(", ", existingSentinels));
+
+        var baselineTables = new[] { "anti_cheat_flags", "users", "matches", "Missions", "Tiers" };
+        var canBaseline = true;
+        foreach (var table in baselineTables)
+        {
+            if (!await TableExistsAsync(db, table, ct))
+            {
+                canBaseline = false;
+                break;
+            }
+        }
+
+        if (canBaseline)
+        {
+            var allMigrations = await db.Database.GetMigrationsAsync(ct);
+            var lastMigration = allMigrations.LastOrDefault();
+
+            if (!string.IsNullOrWhiteSpace(lastMigration))
+            {
+                _log.Warning(
+                    "Baselining EF migration history at '{MigrationId}' because schema already exists.",
+                    lastMigration);
+
+                await EnsureHistoryTableExistsAsync(db, ct);
+                await InsertMigrationHistoryRowIfMissingAsync(db, lastMigration!, ct);
+
+                _log.Information("Baseline complete; skipping schema create migration for existing database.");
+                return true;
+            }
+        }
+
+        if (!autoRepairOnMissingTables)
+        {
+            throw new InvalidOperationException(
+                "Database has existing tables but no EF migration history and cannot be safely baselined. " +
+                "Enable MigrationService:AutoRepairOnMissingTables=true to auto-repair in dev/CI, " +
+                "or reset the DB volume, then rerun MigrationService.");
+        }
+
+        _log.Warning("AutoRepairOnMissingTables=true. Rebuilding schema before applying migrations (EnsureDeleted + Migrate).");
+        await db.Database.EnsureDeletedAsync(ct);
+        await db.Database.MigrateAsync(ct);
+        _log.Information("Schema drift recovered; EF migrations applied on a clean database.");
+        return true;
+    }
+
+    private static async Task EnsureHistoryTableExistsAsync(AppDb db, CancellationToken ct)
+    {
+        var conn = db.Database.GetDbConnection();
+        var openedHere = false;
+
+        try
+        {
+            if (conn.State != System.Data.ConnectionState.Open)
+            {
+                await conn.OpenAsync(ct);
+                openedHere = true;
+            }
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "CREATE TABLE IF NOT EXISTS \"__EFMigrationsHistory\" (" +
+                "\"MigrationId\" character varying(150) NOT NULL," +
+                "\"ProductVersion\" character varying(32) NOT NULL," +
+                "CONSTRAINT \"PK___EFMigrationsHistory\" PRIMARY KEY (\"MigrationId\")" +
+                ");";
+
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+        finally
+        {
+            if (openedHere)
+                await conn.CloseAsync();
+        }
+    }
+
+    private static async Task InsertMigrationHistoryRowIfMissingAsync(AppDb db, string migrationId, CancellationToken ct)
+    {
+        var conn = db.Database.GetDbConnection();
+        var openedHere = false;
+
+        try
+        {
+            if (conn.State != System.Data.ConnectionState.Open)
+            {
+                await conn.OpenAsync(ct);
+                openedHere = true;
+            }
+
+            await using var cmd = conn.CreateCommand();
+            cmd.CommandText =
+                "INSERT INTO \"__EFMigrationsHistory\" (\"MigrationId\", \"ProductVersion\") " +
+                "VALUES (@migrationId, @productVersion) ON CONFLICT (\"MigrationId\") DO NOTHING;";
+
+            var p1 = cmd.CreateParameter();
+            p1.ParameterName = "@migrationId";
+            p1.Value = migrationId;
+            cmd.Parameters.Add(p1);
+
+            var p2 = cmd.CreateParameter();
+            p2.ParameterName = "@productVersion";
+            p2.Value = "9.0.11";
+            cmd.Parameters.Add(p2);
+
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+        finally
+        {
+            if (openedHere)
+                await conn.CloseAsync();
         }
     }
 

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -247,10 +247,10 @@ services:
     restart: "no"
     environment:
       ASPNETCORE_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT:-Development}"
-      DOTNET_ENVIROMENT: "{ASPNETCORE_ENVIRONMENT:-Development}"
+      DOTNET_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT:-Development}"
       
       # Database connections
-      ConnectionStrings__tycoon_db: "Host=postgres;Port=5432;Database=${POSTGRES_DB:-tycoon_db};Username=${POSTGRES_USER:-tycoon_user};Password=${POSTGRES_PASSWORD:-tycoon_password_123}"
+      ConnectionStrings__db: "Host=postgres;Port=5432;Database=${POSTGRES_DB:-tycoon_db};Username=${POSTGRES_USER:-tycoon_user};Password=${POSTGRES_PASSWORD:-tycoon_password_123}"
       ConnectionStrings__redis: "redis:6379,password=${REDIS_PASSWORD:-tycoon_redis_password_123}"
       ConnectionStrings__mongo: "mongodb://${MONGO_APP_USER:-tycoon_app_user}:${MONGO_APP_PASSWORD:-tycoon_app_password_123}@mongodb:27017/${MONGO_APP_DB:-tycoon_db}?authSource=${MONGO_APP_DB:-tycoon_db}"
       ConnectionStrings__elasticsearch: "http://elasticsearch:9200"


### PR DESCRIPTION
### Motivation

- Docker migration container was miswired (wrong env var/key), causing the migration host to sometimes start with an unresolved DB connection and fail during `docker compose up`.
- Databases that already contain legacy/app tables (notably `anti_cheat_flags`) but have an empty EF migrations history cause the initial EF migration to repeatedly fail with `relation "..." already exists` and block automated startup in dev/CI.
- The `AntiCheatFlag` domain code created a mismatch between supplied timestamps/evidence and persisted values which could produce surprising runtime data.

### Description

- Fixed docker compose wiring for the migration container by correcting `DOTNET_ENVIRONMENT` interpolation and switching the migration DB env key to `ConnectionStrings__db` (the key resolved by the infrastructure code). (`docker/compose.yml`)
- Made the initial migration idempotent for the critical anti-cheat object by replacing the EF-generated `CreateTable`/`CreateIndex` for `anti_cheat_flags` with raw SQL `CREATE TABLE IF NOT EXISTS` and `CREATE INDEX IF NOT EXISTS` statements so creation becomes safe on pre-existing schemas. (`Tycoon.Backend.Migrations/Migrations/20260217200552_InitialCreate.cs`)
- Added a robust pre-migration baseline/repair flow in `MigrationWorker`: `TryBaselineOrRepairFromPreExistingSchemaAsync(...)` detects the pattern “no applied EF migrations + sentinel tables exist”, attempts to baseline EF history (creates `__EFMigrationsHistory` and inserts the latest migration row) when safe, and otherwise falls back to the existing `EnsureDeleted + Migrate` repair path when `MigrationService:AutoRepairOnMissingTables=true`. (`Tycoon.MigrationService/MigrationWorker.cs`)
- Implemented helpers `EnsureHistoryTableExistsAsync` and `InsertMigrationHistoryRowIfMissingAsync` to create/seed the EF history table when baselining. (`Tycoon.MigrationService/MigrationWorker.cs`)
- Fixed anti-cheat domain issues so the constructor honors the supplied `createdAtUtc` and `LeaderLeftPartyDuringMatch` persists the generated evidence JSON rather than `null`. (`Tycoon.Backend.Domain/Entities/AntiCheatFlag.cs`)

### Testing

- Inspected and validated all relevant files using repository searches and prints with `rg` and `sed`, confirming the new baseline logic is invoked before `Database.MigrateAsync()` and that migration SQL targets `anti_cheat_flags` only. (succeeded)
- Verified code diffs and committed the changes with `git add`/`git commit` to record the patch. (succeeded)
- Attempted to validate the Docker configuration with `docker compose -f docker/compose.yml config` but the environment does not have the Docker CLI so that check failed here; runtime `docker compose` validation should be run locally or in CI. (failed due to missing `docker`)
- Could not run `dotnet build` or execute the migration container in this environment because the `dotnet`/Docker CLI is not available here; please run `dotnet build` and `docker compose -f docker/compose.yml up -d --build` in your environment/CI to fully validate runtime behavior. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d2c57e2ec832d90cc563d0614fb89)