### PR TITLE
Harden admin JWT policies and add rate limits for admin auth/notifications

### DIFF
--- a/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application.Auth;
 using Tycoon.Shared.Contracts.Dtos;
 
@@ -27,7 +28,7 @@ public static class AdminAuthEndpoints
 
         g.MapPost("/login", Login).RequireRateLimiting("admin-auth-login");
         g.MapPost("/refresh", Refresh).RequireRateLimiting("admin-auth-refresh");
-        g.MapGet("/me", Me).RequireAuthorization();
+        g.MapGet("/me", Me).RequireAuthorization(AdminPolicies.AdminOpsPolicy);
     }
 
     private static async Task<IResult> Login(

--- a/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Domain.Entities;
 using Tycoon.Shared.Contracts.Dtos;
@@ -62,7 +63,9 @@ public static class AdminNotificationsEndpoints
 
             await db.SaveChangesAsync(ct);
             return Results.Accepted(value: new AdminNotificationSendResponse(jobId, EstimatedRecipients: 0));
-        });
+        })
+        .RequireAuthorization(AdminPolicies.AdminNotificationsWritePolicy)
+        .RequireRateLimiting("admin-notifications-send");
 
         g.MapPost("/schedule", async ([FromBody] AdminNotificationScheduleRequest request, IAppDb db, CancellationToken ct) =>
         {
@@ -76,7 +79,9 @@ public static class AdminNotificationsEndpoints
             await db.SaveChangesAsync(ct);
 
             return Results.Created($"/admin/notifications/scheduled/{scheduleId}", new AdminNotificationScheduleResponse(scheduleId));
-        });
+        })
+        .RequireAuthorization(AdminPolicies.AdminNotificationsWritePolicy)
+        .RequireRateLimiting("admin-notifications-send");
 
         g.MapGet("/scheduled", async ([FromQuery] int page, [FromQuery] int pageSize, IAppDb db, CancellationToken ct) =>
         {

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -76,7 +76,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddOptions<JwtSettings>()
-    .BindConfiguration("Jwt")           // binds appsettings "Jwt" section
+    .BindConfiguration("JwtSettings")   // binds appsettings "JwtSettings" section
     .ValidateDataAnnotations()          // enforces [Required], [MinLength], [Range]
     .ValidateOnStart();                 // fails at startup, not first request
 
@@ -254,10 +254,10 @@ if (hangfireEnabled)
 }
 
 // JWT Authentication
-var jwtKey = builder.Configuration["Auth:JwtKey"];
-if (string.IsNullOrWhiteSpace(jwtKey))
+var jwtSettings = builder.Configuration.GetSection("JwtSettings").Get<JwtSettings>() ?? new JwtSettings();
+if (string.IsNullOrWhiteSpace(jwtSettings.SecretKey))
 {
-    jwtKey = "dev-only-change-me-dev-only-change-me-dev-only-change-me";
+    jwtSettings.SecretKey = "dev-only-change-me-dev-only-change-me-dev-only-change-me";
     Console.WriteLine("⚠️ Using default JWT key for development!");
 }
 
@@ -269,13 +269,16 @@ builder.Services
         o.SaveToken = true;
         o.TokenValidationParameters = new TokenValidationParameters
         {
-            ValidateIssuer = false,
-            ValidateAudience = false,
+            ValidateIssuer = true,
+            ValidIssuer = jwtSettings.Issuer,
+            ValidateAudience = true,
+            ValidAudiences = new[] { "mobile-app", "admin-app", jwtSettings.Audience },
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey)),
             ValidateLifetime = true,
             ClockSkew = TimeSpan.FromMinutes(2),
-            NameClaimType = "sub"
+            NameClaimType = "sub",
+            RoleClaimType = "role"
         };
 
         o.Events = new JwtBearerEvents
@@ -326,6 +329,48 @@ builder.Services.AddRateLimiter(options =>
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 100,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-auth-login", httpContext =>
+    {
+        var key = $"admin-auth-login:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-auth-refresh", httpContext =>
+    {
+        var key = $"admin-auth-refresh:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-notifications-send", httpContext =>
+    {
+        var subject = httpContext.User.FindFirstValue("sub")
+            ?? httpContext.Connection.RemoteIpAddress?.ToString()
+            ?? "unknown";
+        var key = $"admin-notifications-send:{subject}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 20,
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0
             });


### PR DESCRIPTION
### Motivation
- Move admin flows from permissive checks to strict JWT role/scope/audience enforcement and add abuse protections for high-risk admin endpoints.

### Description
- Bind JWT options to the `JwtSettings` section and tighten bearer validation to require issuer, valid audiences, signing key, token lifetime, and a mapped `role` claim in the JWT pipeline.
- Introduce rate limiter policies `admin-auth-login`, `admin-auth-refresh`, and `admin-notifications-send` and apply them to admin auth endpoints and notification send/schedule endpoints.
- Add `AdminOpsPolicy` and `AdminNotificationsWritePolicy` which require `role: admin`, `aud: admin-app`, and the appropriate scope check via a new `HasScope` helper, and apply `AdminOpsPolicy` to `/admin/auth/me` and `AdminNotificationsWritePolicy` to `/admin/notifications/send` and `/admin/notifications/schedule`.
- Harden the admin route-group guard to perform strict JWT role/audience/scope checks in non-test environments while preserving the existing `Testing:UseInMemoryDb` bypass for tests.

### Testing
- Ran `git diff --check` to validate diffs (passed).
- Attempted `dotnet test Tycoon.Backend.Api.Tests/Tycoon.Backend.Api.Tests.csproj --no-restore` but could not run automated tests because `dotnet` is not installed in this environment (`command not found`).
- Changes were exercised via local code inspection and staged for commit; automated test execution should be run in CI or a local environment with the .NET SDK installed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3a287d8832d9b672c9bb2571bc5)