### PR TITLE
Enforce admin authorization and rate limits, improve JWT config, and add admin security contract tests

### DIFF
--- a/Tycoon.Backend.Api.Tests/AdminAuth/AdminAuthSecurityContractTests.cs
+++ b/Tycoon.Backend.Api.Tests/AdminAuth/AdminAuthSecurityContractTests.cs
@@ -1,0 +1,104 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using FluentAssertions;
+using Tycoon.Backend.Api.Tests.TestHost;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Tests.AdminAuth;
+
+public sealed class AdminAuthSecurityContractTests : IClassFixture<TycoonApiFactory>
+{
+    private readonly HttpClient _http;
+
+    public AdminAuthSecurityContractTests(TycoonApiFactory factory)
+    {
+        _http = factory.CreateClient().WithAdminOpsKey();
+    }
+
+    [Fact]
+    public async Task AdminMe_WithoutBearer_Returns401()
+    {
+        var resp = await _http.GetAsync("/admin/auth/me");
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task AdminMe_WithUserToken_Returns403()
+    {
+        var userToken = await SignupAndGetUserTokenAsync();
+
+        using var req = new HttpRequestMessage(HttpMethod.Get, "/admin/auth/me");
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", userToken);
+
+        var resp = await _http.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task AdminLogin_InvalidCredentials_Eventually429()
+    {
+        HttpStatusCode? hit = null;
+
+        for (var i = 0; i < 20; i++)
+        {
+            var resp = await _http.PostAsJsonAsync("/admin/auth/login",
+                new AdminLoginRequest("nobody@example.com", "wrong-pass"));
+
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                hit = resp.StatusCode;
+                break;
+            }
+
+            resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+            var json = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            json.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("UNAUTHORIZED");
+        }
+
+        hit.Should().Be(HttpStatusCode.TooManyRequests, "admin auth login should be rate-limited");
+    }
+
+    [Fact]
+    public async Task AdminRefresh_InvalidToken_Eventually429()
+    {
+        HttpStatusCode? hit = null;
+
+        for (var i = 0; i < 30; i++)
+        {
+            var resp = await _http.PostAsJsonAsync("/admin/auth/refresh", new RefreshRequest("bogus-refresh-token"));
+
+            if (resp.StatusCode == HttpStatusCode.TooManyRequests)
+            {
+                hit = resp.StatusCode;
+                break;
+            }
+
+            resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+
+            var json = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+            json.RootElement.GetProperty("error").GetProperty("code").GetString().Should().Be("UNAUTHORIZED");
+        }
+
+        hit.Should().Be(HttpStatusCode.TooManyRequests, "admin auth refresh should be rate-limited");
+    }
+
+    private async Task<string> SignupAndGetUserTokenAsync()
+    {
+        var email = $"user_{Guid.NewGuid():N}@example.com";
+        var password = "Passw0rd!123";
+        var deviceId = $"dev-{Guid.NewGuid():N}";
+
+        var signupResp = await _http.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(email, password, deviceId, Username: $"u_{Guid.NewGuid():N}"));
+
+        signupResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var signup = await signupResp.Content.ReadFromJsonAsync<SignupResponse>();
+        signup.Should().NotBeNull();
+        signup!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        return signup.AccessToken;
+    }
+}

--- a/Tycoon.Backend.Api.Tests/AdminNotifications/AdminNotificationsSecurityContractTests.cs
+++ b/Tycoon.Backend.Api.Tests/AdminNotifications/AdminNotificationsSecurityContractTests.cs
@@ -1,0 +1,102 @@
+using System.Net;
+using System.Net.Http.Json;
+using FluentAssertions;
+using Tycoon.Backend.Api.Tests.TestHost;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Tests.AdminNotifications;
+
+public sealed class AdminNotificationsSecurityContractTests : IClassFixture<TycoonApiFactory>
+{
+    private readonly HttpClient _http;
+
+    public AdminNotificationsSecurityContractTests(TycoonApiFactory factory)
+    {
+        _http = factory.CreateClient().WithAdminOpsKey();
+    }
+
+    [Fact]
+    public async Task Send_WithoutBearer_Returns401()
+    {
+        var resp = await _http.PostAsJsonAsync("/admin/notifications/send",
+            new AdminNotificationSendRequest("Title", "Body", "admin_basic", new Dictionary<string, object>{{"segment", "all"}}, null));
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Send_WithUserBearer_Returns403()
+    {
+        var userToken = await SignupAndGetUserTokenAsync();
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/admin/notifications/send")
+        {
+            Content = JsonContent.Create(new AdminNotificationSendRequest("Title", "Body", "admin_basic", new Dictionary<string, object>{{"segment", "all"}}, null))
+        };
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", userToken);
+
+        var resp = await _http.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Send_WithAdminBearer_ReturnsAccepted()
+    {
+        var adminToken = await SignupAndGetAdminTokenAsync();
+
+        // seed default channel (admin_basic)
+        using (var seedReq = new HttpRequestMessage(HttpMethod.Get, "/admin/notifications/channels"))
+        {
+            seedReq.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", adminToken);
+            var seedResp = await _http.SendAsync(seedReq);
+            seedResp.StatusCode.Should().Be(HttpStatusCode.OK);
+        }
+
+        using var req = new HttpRequestMessage(HttpMethod.Post, "/admin/notifications/send")
+        {
+            Content = JsonContent.Create(new AdminNotificationSendRequest("Title", "Body", "admin_basic", new Dictionary<string, object>{{"segment", "all"}}, null))
+        };
+        req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", adminToken);
+
+        var resp = await _http.SendAsync(req);
+        resp.StatusCode.Should().Be(HttpStatusCode.Accepted);
+    }
+
+    private async Task<string> SignupAndGetUserTokenAsync()
+    {
+        var email = $"user_{Guid.NewGuid():N}@example.com";
+        var password = "Passw0rd!123";
+        var deviceId = $"dev-{Guid.NewGuid():N}";
+
+        var signupResp = await _http.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(email, password, deviceId, Username: $"u_{Guid.NewGuid():N}"));
+
+        signupResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var signup = await signupResp.Content.ReadFromJsonAsync<SignupResponse>();
+        signup.Should().NotBeNull();
+        signup!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        return signup.AccessToken;
+    }
+
+    private async Task<string> SignupAndGetAdminTokenAsync()
+    {
+        var email = $"admin_{Guid.NewGuid():N}@example.com";
+        var password = "Passw0rd!123";
+        var deviceId = $"dev-{Guid.NewGuid():N}";
+
+        var signupResp = await _http.PostAsJsonAsync("/auth/signup",
+            new SignupRequest(email, password, deviceId, Username: $"adm_{Guid.NewGuid():N}"));
+        signupResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var adminLoginResp = await _http.PostAsJsonAsync("/admin/auth/login", new AdminLoginRequest(email, password));
+        adminLoginResp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var login = await adminLoginResp.Content.ReadFromJsonAsync<AdminLoginResponse>();
+        login.Should().NotBeNull();
+        login!.AccessToken.Should().NotBeNullOrWhiteSpace();
+
+        return login.AccessToken;
+    }
+}

--- a/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application.Auth;
 using Tycoon.Shared.Contracts.Dtos;
 
@@ -27,7 +28,7 @@ public static class AdminAuthEndpoints
 
         g.MapPost("/login", Login).RequireRateLimiting("admin-auth-login");
         g.MapPost("/refresh", Refresh).RequireRateLimiting("admin-auth-refresh");
-        g.MapGet("/me", Me).RequireAuthorization();
+        g.MapGet("/me", Me).RequireAuthorization(AdminPolicies.AdminOpsPolicy);
     }
 
     private static async Task<IResult> Login(

--- a/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.EntityFrameworkCore;
 using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Domain.Entities;
 using Tycoon.Shared.Contracts.Dtos;
@@ -62,7 +63,9 @@ public static class AdminNotificationsEndpoints
 
             await db.SaveChangesAsync(ct);
             return Results.Accepted(value: new AdminNotificationSendResponse(jobId, EstimatedRecipients: 0));
-        });
+        })
+        .RequireAuthorization(AdminPolicies.AdminNotificationsWritePolicy)
+        .RequireRateLimiting("admin-notifications-send");
 
         g.MapPost("/schedule", async ([FromBody] AdminNotificationScheduleRequest request, IAppDb db, CancellationToken ct) =>
         {
@@ -76,7 +79,9 @@ public static class AdminNotificationsEndpoints
             await db.SaveChangesAsync(ct);
 
             return Results.Created($"/admin/notifications/scheduled/{scheduleId}", new AdminNotificationScheduleResponse(scheduleId));
-        });
+        })
+        .RequireAuthorization(AdminPolicies.AdminNotificationsWritePolicy)
+        .RequireRateLimiting("admin-notifications-send");
 
         g.MapGet("/scheduled", async ([FromQuery] int page, [FromQuery] int pageSize, IAppDb db, CancellationToken ct) =>
         {

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -76,7 +76,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services
     .AddOptions<JwtSettings>()
-    .BindConfiguration("Jwt")           // binds appsettings "Jwt" section
+    .BindConfiguration("JwtSettings")   // binds appsettings "JwtSettings" section
     .ValidateDataAnnotations()          // enforces [Required], [MinLength], [Range]
     .ValidateOnStart();                 // fails at startup, not first request
 
@@ -254,10 +254,10 @@ if (hangfireEnabled)
 }
 
 // JWT Authentication
-var jwtKey = builder.Configuration["Auth:JwtKey"];
-if (string.IsNullOrWhiteSpace(jwtKey))
+var jwtSettings = builder.Configuration.GetSection("JwtSettings").Get<JwtSettings>() ?? new JwtSettings();
+if (string.IsNullOrWhiteSpace(jwtSettings.SecretKey))
 {
-    jwtKey = "dev-only-change-me-dev-only-change-me-dev-only-change-me";
+    jwtSettings.SecretKey = "dev-only-change-me-dev-only-change-me-dev-only-change-me";
     Console.WriteLine("⚠️ Using default JWT key for development!");
 }
 
@@ -269,13 +269,16 @@ builder.Services
         o.SaveToken = true;
         o.TokenValidationParameters = new TokenValidationParameters
         {
-            ValidateIssuer = false,
-            ValidateAudience = false,
+            ValidateIssuer = true,
+            ValidIssuer = jwtSettings.Issuer,
+            ValidateAudience = true,
+            ValidAudiences = new[] { "mobile-app", "admin-app", jwtSettings.Audience },
             ValidateIssuerSigningKey = true,
-            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtKey)),
+            IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSettings.SecretKey)),
             ValidateLifetime = true,
             ClockSkew = TimeSpan.FromMinutes(2),
-            NameClaimType = "sub"
+            NameClaimType = "sub",
+            RoleClaimType = "role"
         };
 
         o.Events = new JwtBearerEvents
@@ -326,6 +329,48 @@ builder.Services.AddRateLimiter(options =>
             factory: _ => new FixedWindowRateLimiterOptions
             {
                 PermitLimit = 100,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-auth-login", httpContext =>
+    {
+        var key = $"admin-auth-login:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 5,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-auth-refresh", httpContext =>
+    {
+        var key = $"admin-auth-refresh:{httpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown"}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 10,
+                Window = TimeSpan.FromMinutes(1),
+                QueueLimit = 0
+            });
+    });
+
+    options.AddPolicy("admin-notifications-send", httpContext =>
+    {
+        var subject = httpContext.User.FindFirstValue("sub")
+            ?? httpContext.Connection.RemoteIpAddress?.ToString()
+            ?? "unknown";
+        var key = $"admin-notifications-send:{subject}";
+        return RateLimitPartition.GetFixedWindowLimiter(
+            partitionKey: key,
+            factory: _ => new FixedWindowRateLimiterOptions
+            {
+                PermitLimit = 20,
                 Window = TimeSpan.FromMinutes(1),
                 QueueLimit = 0
             });


### PR DESCRIPTION
### Motivation

- Strengthen admin surface security by enforcing role/audience/scope checks and allowing test bypass for admin ops key flows. 
- Harden JWT configuration and validation to use a named `JwtSettings` section, validate issuer/audience, and include role claim mapping. 
- Protect sensitive admin endpoints with rate limiting and explicit policies and verify behavior with contract tests.

### Description

- Updated JWT configuration to bind `JwtSettings`, use `JwtSettings.SecretKey` as the signing key, validate issuer/audience, and map `role` as `RoleClaimType` in `Program.cs`. 
- Added rate limit policies for admin flows (`admin-auth-login`, `admin-auth-refresh`, and `admin-notifications-send`) and wired them to the relevant endpoints. 
- Enforced authorization policies on admin endpoints by requiring `AdminPolicies.AdminOpsPolicy` for `/admin/auth/me` and `AdminNotificationsWritePolicy` plus rate limiting for notifications endpoints. 
- Expanded `AdminPolicies` to include `AdminOps` and `AdminNotificationsWrite` policies that check authenticated user, `role`, `aud` claim and required scopes, and added a helper `HasScope` method. 
- Enhanced `AdminOpsKeyMiddleware` to allow testing bypass, require authenticated users, verify `role`, `aud`, and presence of required `scope`, and validate allowed admin emails from configuration. 
- Added two integration/security contract tests: `AdminAuthSecurityContractTests` and `AdminNotificationsSecurityContractTests` to validate auth behavior (401/403/429/Accepted) across admin endpoints.

### Testing

- Ran the API tests with `dotnet test Tycoon.Backend.Api.Tests` and the new tests `AdminAuthSecurityContractTests` and `AdminNotificationsSecurityContractTests` executed successfully. 
- Verified admin endpoint behaviors: unauthorized access returns `401`, insufficient role returns `403`, login/refresh rate limits eventually return `429`, and admin notifications `POST /admin/notifications/send` returns `202 Accepted` for admin users. 
- No automated test failures were reported during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a1d3a287d8832d9b672c9bb2571bc5)