### PR TITLE
Normalize JWT configuration keys, improve JWT startup validation, and make admin notification job resilient to missing tables

### DIFF
--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -74,6 +74,19 @@ using Tycoon.Shared.Observability;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Normalize JWT secret configuration across legacy and current key names.
+var normalizedJwtSecret =
+    builder.Configuration["JwtSettings:SecretKey"]
+    ?? builder.Configuration["Jwt:Secret"]
+    ?? builder.Configuration["Auth:JwtKey"]
+    ?? builder.Configuration["JwtKey"];
+
+if (!string.IsNullOrWhiteSpace(normalizedJwtSecret)
+    && string.IsNullOrWhiteSpace(builder.Configuration["JwtSettings:SecretKey"]))
+{
+    builder.Configuration["JwtSettings:SecretKey"] = normalizedJwtSecret;
+}
+
 builder.Services
     .AddOptions<JwtSettings>()
     .BindConfiguration("JwtSettings")   // binds appsettings "JwtSettings" section
@@ -189,10 +202,10 @@ builder.Services.AddInfrastructure(builder.Configuration)
 builder.Services.AddScoped<Tycoon.Backend.Application.Auth.IAuthService, Tycoon.Backend.Application.Auth.AuthService>();
 
 // Validate JWT configuration at startup
-var jwtSecret = builder.Configuration["Jwt:Secret"];
+var jwtSecret = builder.Configuration["JwtSettings:SecretKey"];
 if (string.IsNullOrWhiteSpace(jwtSecret))
 {
-    throw new InvalidOperationException("JWT:Secret configuration is required but not set. Please configure a secure JWT secret key.");
+    throw new InvalidOperationException("JWT secret configuration is required but not set. Configure JwtSettings:SecretKey (or legacy Jwt:Secret/Auth:JwtKey).");
 }
 if (jwtSecret.Length < 32)
 {

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -330,8 +330,10 @@ services:
       AdminOps__Key: "${ADMIN_OPS_KEY:-CHANGE_ME}"
       
       # Auth
-      Auth__JwtKey: "${JWT_SECRET_KEY:-your-super-secret-jwt-key-change-me-in-production-minimum-32-chars}"
-      JWT__Secret: "${JWT_SECRET_KEY:-your-super-secret-jwt-key-change-me-in-production-minimum-32-chars}"
+      JwtSettings__SecretKey: "${JWT_SECRET_KEY:-your-super-secret-jwt-key-change-me-in-production-minimum-32-characters-long}"
+      # Legacy keys kept for backwards compatibility across services/config readers.
+      Auth__JwtKey: "${JWT_SECRET_KEY:-your-super-secret-jwt-key-change-me-in-production-minimum-32-characters-long}"
+      JWT__Secret: "${JWT_SECRET_KEY:-your-super-secret-jwt-key-change-me-in-production-minimum-32-characters-long}"
       
       # Observability
       Observability__ServiceName: "Tycoon.Backend.Api"


### PR DESCRIPTION
### Motivation

- Ensure JWT secret is read reliably from legacy and current configuration keys to avoid startup misconfiguration.
- Make startup JWT validation messages clearer and warn on weak secrets.
- Prevent recurring admin notification job from crashing when related DB tables are not yet present (e.g., before migrations run).
- Update the Docker Compose defaults to prefer the new `JwtSettings:SecretKey` while retaining legacy keys for compatibility.

### Description

- Add normalization logic in `Program.cs` to read JWT secrets from multiple legacy keys (`JwtSettings:SecretKey`, `Jwt:Secret`, `Auth:JwtKey`, `JwtKey`) and populate `JwtSettings:SecretKey` when missing. 
- Change startup JWT validation to use `JwtSettings:SecretKey` and improve the thrown error text and length warning when the key is missing or too short.
- Update `docker/compose.yml` to set `JwtSettings__SecretKey` with a more explicit default and retain legacy `Auth__JwtKey` and `JWT__Secret` environment variables for backward compatibility.
- Make `AdminNotificationDispatchJob.Run` resilient to missing DB schema by catching `Npgsql.PostgresException` for `UndefinedTable`, logging a warning, and returning early instead of failing the job, and add the required `using Npgsql;` import.

### Testing

- Ran `dotnet build` for the solution and it completed successfully.
- Ran `dotnet test` and unit tests completed successfully.
- Validated the Docker Compose file with `docker-compose config` to ensure the environment variable keys are correctly emitted.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2f3a896d4832d94ef15b5c4a42557)