### PR TITLE
Add MinIO S3-compatible object storage to Docker setup

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -45,6 +45,8 @@ The Docker stack provides **infrastructure only**:
 | MongoDB                       | Eventing, analytics, document data              |
 | Redis                         | Caching, SignalR backplane                      |
 | Elasticsearch                 | Search, analytics                               |
+| RabbitMQ                      | Message broker, background jobs                 |
+| MinIO                         | S3-compatible object storage                    |
 | Kibana *(dev profile)*        | Elasticsearch UI                                |
 | pgAdmin *(dev profile)*       | PostgreSQL UI                                   |
 | Mongo Express *(dev profile)* | MongoDB UI                                      |
@@ -165,6 +167,9 @@ localhost:6379,password=...
 
 Elasticsearch:
 http://localhost:9200
+
+MinIO (S3-compatible):
+Endpoint=localhost:9000;AccessKey=tycoon_minio_user;SecretKey=...;UseSSL=false
 ```
 
 ---
@@ -217,13 +222,14 @@ dotnet run --project Tycoon.MigrationService/Tycoon.MigrationService.csproj
 
 ## 7. Dev Tooling URLs (Option A or B)
 
-| Tool          | URL                                                              |
-| ------------- | ---------------------------------------------------------------- |
-| Swagger       | [http://localhost:5000/swagger](http://localhost:5000/swagger)   |
-| pgAdmin       | [http://localhost:5050](http://localhost:5050)                   |
-| Mongo Express | [http://localhost:8081](http://localhost:8081)                   |
-| Kibana        | [http://localhost:5601](http://localhost:5601)                   |
-| Hangfire      | [http://localhost:5000/hangfire](http://localhost:5000/hangfire) |
+| Tool           | URL                                                              |
+| -------------- | ---------------------------------------------------------------- |
+| Swagger        | [http://localhost:5000/swagger](http://localhost:5000/swagger)   |
+| pgAdmin        | [http://localhost:5050](http://localhost:5050)                   |
+| Mongo Express  | [http://localhost:8081](http://localhost:8081)                   |
+| Kibana         | [http://localhost:5601](http://localhost:5601)                   |
+| Hangfire       | [http://localhost:5000/hangfire](http://localhost:5000/hangfire) |
+| MinIO Console  | [http://localhost:9001](http://localhost:9001)                   |
 
 ---
 
@@ -536,6 +542,11 @@ docker compose -f docker/compose.yml exec rabbitmq \
   rabbitmq-diagnostics ping
 ```
 
+**MinIO**
+```bash
+curl -f http://localhost:9000/minio/health/live
+```
+
 **Backend API** (when running)
 ```bash
 curl http://localhost:5000/healthz
@@ -548,6 +559,7 @@ curl http://localhost:5000/healthz
 - Redis: "PONG"
 - Elasticsearch: status "yellow" or "green"
 - RabbitMQ: "pong"
+- MinIO: HTTP 200 OK
 - API: HTTP 200 OK
 
 ---

--- a/docker/.env
+++ b/docker/.env
@@ -49,6 +49,13 @@ RABBITMQ_VHOST=tycoon                           # RabbitMQ virtual host
 RABBITMQ_PORT=5672                              # RabbitMQ AMQP port
 RABBITMQ_MANAGEMENT_PORT=15672                  # RabbitMQ management UI port
 
+# --- MinIO Configuration ---
+# S3-compatible object storage for file uploads, assets, and binary data
+MINIO_ROOT_USER=tycoon_minio_user               # MinIO root username (CHANGE IN PRODUCTION!)
+MINIO_ROOT_PASSWORD=tycoon_minio_password_123   # MinIO root password (CHANGE IN PRODUCTION!)
+MINIO_PORT=9000                                 # MinIO S3 API port
+MINIO_CONSOLE_PORT=9001                         # MinIO web console port
+
 # --- Optional Admin UIs (dev profile only) ---
 # These services are only started with: make -f docker/MakeFile up-dev
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -37,6 +37,12 @@ RABBITMQ_VHOST=tycoon
 RABBITMQ_PORT=5672
 RABBITMQ_MANAGEMENT_PORT=15672
 
+# --- MinIO ---
+MINIO_ROOT_USER=tycoon_minio_user
+MINIO_ROOT_PASSWORD=tycoon_minio_password_123
+MINIO_PORT=9000
+MINIO_CONSOLE_PORT=9001
+
 # --- Optional Admin UIs (dev profile) ---
 PGADMIN_DEFAULT_EMAIL=admin@tycoon.local
 PGADMIN_DEFAULT_PASSWORD=admin_password_123

--- a/docker/MakeFile
+++ b/docker/MakeFile
@@ -1,4 +1,4 @@
-.PHONY: help up up-dev up-prod down restart logs ps clean health migrate shell-postgres shell-mongo shell-redis api-logs migration-logs
+.PHONY: help up up-dev up-prod down restart logs ps clean health migrate shell-postgres shell-mongo shell-redis shell-minio api-logs migration-logs
 
 # Docker Compose file paths
 COMPOSE = docker compose -f docker/compose.yml
@@ -22,6 +22,7 @@ help:
 	@echo "  make shell-postgres     Open PostgreSQL shell"
 	@echo "  make shell-mongo        Open MongoDB shell"
 	@echo "  make shell-redis        Open Redis CLI"
+	@echo "  make shell-minio        Open MinIO shell"
 	@echo ""
 	@echo "Monitoring:"
 	@echo "  make health             Check health of all services"
@@ -84,6 +85,9 @@ shell-mongo:
 shell-redis:
 	@$(COMPOSE) exec redis redis-cli -a "$${REDIS_PASSWORD:-tycoon_redis_password_123}"
 
+shell-minio:
+	@$(COMPOSE) exec minio sh
+
 # ===================================
 # Monitoring Commands
 # ===================================
@@ -102,6 +106,9 @@ health:
 	@echo ""
 	@echo "Elasticsearch:"
 	@curl -fsS -u elastic:$${ELASTIC_PASSWORD:-tycoon_elastic_password_123} http://localhost:$${ELASTICSEARCH_PORT:-9200}/_cluster/health?pretty 2>/dev/null | grep -q '"status"' && echo "  ✅ Healthy" || echo "  ❌ Not ready"
+	@echo ""
+	@echo "MinIO:"
+	@curl -fsS http://localhost:$${MINIO_PORT:-9000}/minio/health/live 2>/dev/null && echo "  ✅ Healthy" || echo "  ❌ Not ready"
 	@echo ""
 	@echo "Backend API:"
 	@curl -fsS http://localhost:$${BACKEND_HTTP_PORT:-5000}/healthz 2>/dev/null && echo "  ✅ Healthy" || echo "  ❌ Not ready"

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -60,6 +60,16 @@ services:
         max-size: "10m"
         max-file: "5"
 
+  minio:
+    ports: []
+    environment:
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:?MINIO_ROOT_PASSWORD is required in prod}"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
   # Explicitly disable dev-only tools in prod
   kibana:
     profiles: ["disabled"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -114,6 +114,29 @@ services:
       retries: 10
 
   # ================================
+  # Object Storage
+  # ================================
+  minio:
+    image: minio/minio:latest
+    container_name: tycoon_minio
+    restart: unless-stopped
+    ports:
+      - "${MINIO_PORT:-9000}:9000"
+      - "${MINIO_CONSOLE_PORT:-9001}:9001"
+    environment:
+      MINIO_ROOT_USER: "${MINIO_ROOT_USER:-tycoon_minio_user}"
+      MINIO_ROOT_PASSWORD: "${MINIO_ROOT_PASSWORD:-tycoon_minio_password_123}"
+    volumes:
+      - minio_data:/data
+    command: server /data --console-address ":9001"
+    networks: [tycoon-net]
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  # ================================
   # Monitoring (Dev Profile)
   # ================================
   prometheus:
@@ -377,6 +400,7 @@ volumes:
   redis_data:
   elasticsearch_data:
   rabbitmq_data:
+  minio_data:
   pgadmin_data:
   prometheus_data:
   grafana_data:


### PR DESCRIPTION
Adds a MinIO service to the Docker Compose stack as core infrastructure
for S3-compatible object storage (file uploads, assets, binary data).

- compose.yml: new `minio` service on ports 9000 (API) and 9001 (console),
  with healthcheck, persistent volume, and tycoon-net network
- compose.prod.yml: prod override hides ports and enforces required password
- .env / .env.example: MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, MINIO_PORT,
  MINIO_CONSOLE_PORT variables with dev defaults
- MakeFile: adds MinIO to health check output and new `shell-minio` target
- Docker.md: documents MinIO in services table, connection strings, dev
  tooling URLs, and health check reference

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc