### PR TITLE
Fix operator dashboard antiforgery/cookie errors by persisting Data P…

### DIFF
--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.DataProtection;
 using Tycoon.OperatorDashboard.Services;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -7,6 +8,12 @@ builder.AddServiceDefaults();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
+
+// Persist Data Protection keys so antiforgery tokens and auth cookies survive container restarts.
+var dpKeysPath = builder.Configuration["DataProtection:KeysPath"] ?? "/app/dp-keys";
+builder.Services
+    .AddDataProtection()
+    .PersistKeysToFileSystem(new DirectoryInfo(dpKeysPath));
 
 builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
     .AddCookie(options =>

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -444,6 +444,10 @@ services:
       # Point to tycoon-api via Docker service name
       services__tycoon-api__http__0: "http://backend-api:5000"
       AdminOps__Key: "${ADMIN_OPS_KEY:-CHANGE_ME}"
+      # Persist Data Protection keys across restarts (fixes antiforgery / cookie decryption errors)
+      DataProtection__KeysPath: "/app/dp-keys"
+    volumes:
+      - dashboard_dp_keys:/app/dp-keys
     depends_on:
       backend-api:
         condition: service_healthy
@@ -476,3 +480,4 @@ volumes:
   pgadmin_data:
   prometheus_data:
   grafana_data:
+  dashboard_dp_keys:


### PR DESCRIPTION
…rotection keys

The dashboard was storing Data Protection keys in the container's ephemeral filesystem. On every restart a new key ring was generated, invalidating all existing antiforgery tokens and auth cookies — causing the 'key not found in key ring' cryptographic exception on form submissions.

- Program.cs: call AddDataProtection().PersistKeysToFileSystem() reading the path from DataProtection:KeysPath config (default: /app/dp-keys).
- compose.yml: set DataProtection__KeysPath env var and mount a named Docker volume (dashboard_dp_keys) so keys survive container rebuilds/restarts.

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc