### PR TITLE
Fix operator dashboard login: send X-Admin-Ops-Key on all requests

### DIFF
--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -40,6 +40,12 @@ builder.Services.AddHttpClient<AdminApiClient>(client =>
                   ?? builder.Configuration["services:tycoon-api:http:0"]
                   ?? "http://localhost:5000";
     client.BaseAddress = new Uri(backendUrl);
+
+    // Attach the ops key as a default header so every request — including the
+    // initial login — passes the AdminOpsKeyMiddleware / endpoint filter gate.
+    var opsKey = builder.Configuration["AdminOps:Key"] ?? string.Empty;
+    if (!string.IsNullOrEmpty(opsKey))
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Admin-Ops-Key", opsKey);
 });
 
 var app = builder.Build();


### PR DESCRIPTION
The /admin/auth/login endpoint is protected by RequireAdminOpsKey() endpoint filter, which returns 401 when the header is missing — before credentials are even validated. AdminApiClient.SetToken() was the only place the ops key was attached, but it's called after a successful login, not before.

Fix: set the X-Admin-Ops-Key as a default header on the typed HttpClient at construction time so every request (including the initial login) carries it.

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc