### PR TITLE
Fix operator dashboard auth: token expiry, refresh, logout CSRF, cook…

### DIFF
--- a/Tycoon.OperatorDashboard/Components/Pages/AntiCheat.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/AntiCheat.razor
@@ -179,7 +179,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         await LoadFlagsAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Components/Pages/AuditLog.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/AuditLog.razor
@@ -58,7 +58,7 @@ else if (_doc.RootElement.TryGetProperty("items", out var items))
     private string _status = string.Empty;
     private int _page = 1;
 
-    protected override async Task OnInitializedAsync() { Auth.TryAttachToken(); await LoadAsync(); }
+    protected override async Task OnInitializedAsync() { await Auth.TryAttachTokenAsync(); await LoadAsync(); }
 
     private async Task LoadAsync()
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Dashboard.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Dashboard.razor
@@ -34,7 +34,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         _config = await Api.GetConfigAsync();
     }
 }

--- a/Tycoon.OperatorDashboard/Components/Pages/Economy.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Economy.razor
@@ -93,7 +93,7 @@
     private long _grantAmount = 100;
     private string _grantReason = string.Empty, _grantMsg = string.Empty;
 
-    protected override void OnInitialized() => Auth.TryAttachToken();
+    protected override async Task OnInitializedAsync() => await Auth.TryAttachTokenAsync();
 
     private async Task LookupAsync()
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Events.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Events.razor
@@ -52,7 +52,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         await LoadAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Components/Pages/FeatureFlags.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/FeatureFlags.razor
@@ -41,7 +41,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         await LoadAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Components/Pages/Matches.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Matches.razor
@@ -42,7 +42,7 @@ else if (_doc.RootElement.TryGetProperty("items", out var items))
     private JsonDocument? _doc;
     private int _page = 1;
 
-    protected override async Task OnInitializedAsync() { Auth.TryAttachToken(); await LoadAsync(); }
+    protected override async Task OnInitializedAsync() { await Auth.TryAttachTokenAsync(); await LoadAsync(); }
     private async Task LoadAsync() => _doc = await Api.ListMatchesAsync(_page);
     private async Task PrevPage() { if (_page > 1) { _page--; await LoadAsync(); } }
     private async Task NextPage() { _page++; await LoadAsync(); }

--- a/Tycoon.OperatorDashboard/Components/Pages/Media.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Media.razor
@@ -63,7 +63,7 @@
     private JsonDocument? _intent;
     private string _intentJson = string.Empty;
 
-    protected override void OnInitialized() => Auth.TryAttachToken();
+    protected override async Task OnInitializedAsync() => await Auth.TryAttachTokenAsync();
 
     private void OnFileChanged(InputFileChangeEventArgs e)
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Moderation.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Moderation.razor
@@ -150,7 +150,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         await LoadEscalationsAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Components/Pages/Notifications.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Notifications.razor
@@ -178,7 +178,7 @@
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         _channels = await Api.ListChannelsAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Components/Pages/Powerups.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Powerups.razor
@@ -103,7 +103,7 @@
     private string _grantMsg = string.Empty;
     private bool _grantError;
 
-    protected override void OnInitialized() => Auth.TryAttachToken();
+    protected override async Task OnInitializedAsync() => await Auth.TryAttachTokenAsync();
 
     private async Task LookupAsync()
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Questions.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Questions.razor
@@ -91,7 +91,7 @@ else
     private string _editText = string.Empty, _editCategory = string.Empty, _editTags = string.Empty;
     private string _editMsg = string.Empty;
 
-    protected override async Task OnInitializedAsync() { Auth.TryAttachToken(); await LoadAsync(); }
+    protected override async Task OnInitializedAsync() { await Auth.TryAttachTokenAsync(); await LoadAsync(); }
 
     private async Task LoadAsync()
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Seasons.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Seasons.razor
@@ -99,7 +99,7 @@
     private string _rewardSeasonId = string.Empty, _rewardPlayerId = string.Empty;
     private Guid? _confirmCloseId;
 
-    protected override async Task OnInitializedAsync() { Auth.TryAttachToken(); await LoadAsync(); }
+    protected override async Task OnInitializedAsync() { await Auth.TryAttachTokenAsync(); await LoadAsync(); }
 
     private async Task SwitchTab(string tab)
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Skills.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Skills.razor
@@ -57,7 +57,7 @@
     private string _message = string.Empty;
     private string? _resultJson;
 
-    protected override void OnInitialized() => Auth.TryAttachToken();
+    protected override async Task OnInitializedAsync() => await Auth.TryAttachTokenAsync();
 
     private async Task SeedAsync()
     {

--- a/Tycoon.OperatorDashboard/Components/Pages/Users.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Users.razor
@@ -70,7 +70,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        Auth.TryAttachToken();
+        await Auth.TryAttachTokenAsync();
         await LoadAsync();
     }
 

--- a/Tycoon.OperatorDashboard/Pages/Logout.cshtml
+++ b/Tycoon.OperatorDashboard/Pages/Logout.cshtml
@@ -1,2 +1,12 @@
 @page
 @model Tycoon.OperatorDashboard.Pages.LogoutModel
+<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="utf-8" /><title>Signing out…</title></head>
+<body>
+    <form method="post" id="logoutForm">
+        @Html.AntiForgeryToken()
+    </form>
+    <script>document.getElementById('logoutForm').submit();</script>
+</body>
+</html>

--- a/Tycoon.OperatorDashboard/Pages/Logout.cshtml.cs
+++ b/Tycoon.OperatorDashboard/Pages/Logout.cshtml.cs
@@ -6,7 +6,11 @@ namespace Tycoon.OperatorDashboard.Pages;
 
 public sealed class LogoutModel(AdminAuthService auth) : PageModel
 {
-    public async Task<IActionResult> OnGetAsync()
+    // GET: renders the auto-submitting POST form — never executes the logout directly.
+    public IActionResult OnGet() => Page();
+
+    // POST (with antiforgery): performs the actual sign-out.
+    public async Task<IActionResult> OnPostAsync()
     {
         await auth.LogoutAsync();
         return RedirectToPage("/Login");

--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -24,6 +24,7 @@ builder.Services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationSc
         options.SlidingExpiration = true;
         options.Cookie.HttpOnly = true;
         options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+        options.Cookie.SameSite = SameSiteMode.Strict;
     });
 
 builder.Services.AddAuthorization();

--- a/Tycoon.OperatorDashboard/Services/AdminApiClient.cs
+++ b/Tycoon.OperatorDashboard/Services/AdminApiClient.cs
@@ -425,6 +425,11 @@ public sealed class AdminApiClient(HttpClient http, IConfiguration config)
         if (!string.IsNullOrEmpty(opsKey))
             http.DefaultRequestHeaders.TryAddWithoutValidation("X-Admin-Ops-Key", opsKey);
     }
+
+    public void ClearToken()
+    {
+        http.DefaultRequestHeaders.Authorization = null;
+    }
 }
 
 // ── Local response types ──────────────────────────────────────────────────────

--- a/Tycoon.OperatorDashboard/Services/AdminAuthService.cs
+++ b/Tycoon.OperatorDashboard/Services/AdminAuthService.cs
@@ -41,20 +41,36 @@ public sealed class AdminAuthService(
     {
         var userId = httpCtx.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (userId is not null) tokens.Remove(userId);
+        api.ClearToken();
         await httpCtx.HttpContext!.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
     }
 
     /// <summary>
     /// Attaches the stored token to the AdminApiClient for the current user.
-    /// Call this at the top of any Blazor component that makes API calls.
+    /// Proactively refreshes the access token if it expires within 5 minutes.
+    /// Call this at the top of every Blazor component that makes API calls.
     /// </summary>
-    public bool TryAttachToken()
+    public async Task<bool> TryAttachTokenAsync(CancellationToken ct = default)
     {
         var userId = httpCtx.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (userId is null) return false;
 
         var entry = tokens.Get(userId);
         if (entry is null) return false;
+
+        // Proactively refresh when the access token expires within 5 minutes.
+        if (entry.ExpiresAt <= DateTimeOffset.UtcNow.AddMinutes(5))
+        {
+            var refreshed = await api.RefreshAsync(entry.RefreshToken, ct);
+            if (refreshed is null)
+            {
+                tokens.Remove(userId);
+                return false;
+            }
+            var newExpiry = DateTimeOffset.UtcNow.AddSeconds(refreshed.ExpiresIn);
+            tokens.Set(userId, refreshed.AccessToken, entry.RefreshToken, newExpiry);
+            entry = new TokenStore.TokenEntry(refreshed.AccessToken, entry.RefreshToken, newExpiry);
+        }
 
         api.SetToken(entry.AccessToken);
         return true;

--- a/Tycoon.OperatorDashboard/Services/TokenStore.cs
+++ b/Tycoon.OperatorDashboard/Services/TokenStore.cs
@@ -18,7 +18,15 @@ public sealed class TokenStore
     public TokenEntry? Get(string userId)
     {
         lock (_lock)
-            return _tokens.GetValueOrDefault(userId);
+        {
+            if (!_tokens.TryGetValue(userId, out var entry)) return null;
+            if (entry.ExpiresAt <= DateTimeOffset.UtcNow)
+            {
+                _tokens.Remove(userId);
+                return null;
+            }
+            return entry;
+        }
     }
 
     public void Remove(string userId)


### PR DESCRIPTION
…ie hardening

TokenStore:
- Get() now validates expiry: returns null and evicts expired tokens rather than handing out stale entries that cause silent API failures.

AdminAuthService:
- Replaced sync TryAttachToken() with async TryAttachTokenAsync() that proactively refreshes the access token when it expires within 5 minutes, using the stored refresh token. Returns false and evicts the session if refresh fails (forcing re-login).
- LogoutAsync() now calls api.ClearToken() so the Bearer header is removed from the HttpClient immediately on sign-out.

AdminApiClient:
- Added ClearToken() to null out the Authorization header on logout.

Program.cs:
- Added SameSite=Strict to the auth cookie to prevent CSRF via cross-site requests carrying the session cookie.

Logout:
- Converted from unauthenticated GET to a POST with antiforgery token. The page auto-submits a hidden form so the /logout link still works as a normal navigation. GET now just renders the form (no sign-out side-effect).

All 15 Blazor page components:
- 4 sync OnInitialized() methods converted to async OnInitializedAsync() so token attachment is properly awaited before the component renders.
- All 15 components updated from TryAttachToken() to TryAttachTokenAsync() so they benefit from proactive token refresh.

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc