### PR TITLE
Fix C# switch expression syntax and reorder admin endpoints

### DIFF
--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -661,7 +661,6 @@ GameEventStatsEndpoints.Map(app);
 GameEventStatsEndpoints.MapTerritory(app);
 GuardiansEndpoints.Map(app);
 TerritoryEndpoints.Map(app);
-AdminGameEventsEndpoints.Map(admin);
 
 // Mobile endpoints (separate route surface for mobile-specific contracts/workflows)
 var mobile = app.MapGroup("/mobile").WithTags("Mobile").WithOpenApi();
@@ -678,6 +677,7 @@ var admin = app.MapGroup("/admin")
     .RequireAdminOpsKey()
     .RequireAdminRoleClaims();
 
+AdminGameEventsEndpoints.Map(admin);
 AdminQuestionsEndpoints.Map(admin);
 AdminUsersEndpoints.Map(admin);
 AdminEventQueueEndpoints.Map(admin);

--- a/Tycoon.OperatorDashboard/Components/Pages/Media.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Media.razor
@@ -213,8 +213,8 @@ else
 
     private static string FormatSize(long bytes) => bytes switch
     {
-        < 1024 => $"{bytes} B",
-        < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
+        _ when bytes < 1024 => $"{bytes} B",
+        _ when bytes < 1024 * 1024 => $"{bytes / 1024.0:F1} KB",
         _ => $"{bytes / (1024.0 * 1024):F1} MB"
     };
 }
@@ -230,7 +230,7 @@ else
     .file-size, .file-type { color:#64748b; font-size:.8rem; }
     .spinner { display:inline-block; width:14px; height:14px; border:2px solid rgba(255,255,255,.4);
         border-top-color:#fff; border-radius:50%; animation:spin .7s linear infinite; margin-right:.5rem; }
-    @keyframes spin { to { transform:rotate(360deg); } }
+    @@keyframes spin { to { transform:rotate(360deg); } }
     .result-box { margin-top:.75rem; padding:.75rem 1rem; background:#f8fafc; border:1px solid #e2e8f0;
         border-radius:8px; display:flex; flex-direction:column; gap:.5rem; }
     .result-row { display:flex; gap:.75rem; align-items:baseline; font-size:.875rem; }


### PR DESCRIPTION
## Summary
This PR fixes a C# syntax error in the Media component and reorganizes the endpoint mapping order in Program.cs to ensure proper initialization sequence.

## Key Changes
- **Media.razor**: Updated switch expression pattern matching syntax from relational patterns (`< 1024`) to guard clauses (`_ when bytes < 1024`) for C# compatibility
- **Media.razor**: Fixed CSS `@keyframes` escaping by using `@@keyframes` in the Razor component
- **Program.cs**: Moved `AdminGameEventsEndpoints.Map(admin)` call to after the admin route group configuration is complete, ensuring it's mapped with the correct middleware and authorization requirements

## Notable Details
The relational pattern syntax in switch expressions may not be supported in the project's C# version, necessitating the conversion to guard clause patterns. The endpoint mapping reordering ensures that admin game events endpoints are configured with the same authorization context (`RequireAdminOpsKey()` and `RequireAdminRoleClaims()`) as other admin endpoints.

https://claude.ai/code/session_01K5mynMMCjV7aCpUHubW767