### PR TITLE
fix(routing) + feat(media): fix AdminMedia double-prefix; add MinIO p…

### DIFF
--- a/Tycoon.Backend.Api.Tests/AdminMedia/AdminMediaTests.cs
+++ b/Tycoon.Backend.Api.Tests/AdminMedia/AdminMediaTests.cs
@@ -11,15 +11,13 @@ namespace Tycoon.Backend.Api.Tests.AdminMedia
     public sealed class AdminMediaTests : IClassFixture<TycoonApiFactory>
     {
         private readonly TycoonApiFactory _factory;
-    private readonly HttpClient _http;
+        private readonly HttpClient _http;
 
         public AdminMediaTests(TycoonApiFactory factory)
         {
             _factory = factory;
             _http = factory.CreateClient().WithAdminOpsKey();
         }
-
-
 
         [Fact]
         public async Task Media_Intent_Rejects_Wrong_OpsKey()
@@ -52,7 +50,9 @@ namespace Tycoon.Backend.Api.Tests.AdminMedia
             var dto = await resp.Content.ReadFromJsonAsync<UploadIntentDto>();
             dto.Should().NotBeNull();
             dto!.AssetKey.Should().Contain("uploads/");
+            // In test env (no MinIO), MediaService falls back to the API-proxied upload path.
             dto.UploadUrl.Should().Contain("/admin/media/upload/");
+            dto.ExpiresAtUtc.Should().BeAfter(DateTimeOffset.UtcNow);
         }
 
         [Fact]

--- a/Tycoon.Backend.Api/Features/AdminMedia/AdminMediaEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminMedia/AdminMediaEndpoints.cs
@@ -12,11 +12,11 @@ namespace Tycoon.Backend.Api.Features.AdminMedia
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/admin/media").WithTags("Admin/Media").WithOpenApi();
+            var g = admin.MapGroup("/media").WithTags("Admin/Media").WithOpenApi();
 
-            g.MapPost("/intent", ([FromBody] CreateUploadIntentRequest req, MediaService media) =>
+            g.MapPost("/intent", async ([FromBody] CreateUploadIntentRequest req, MediaService media, CancellationToken ct) =>
             {
-                var dto = media.CreateUploadIntent(req);
+                var dto = await media.CreateUploadIntentAsync(req, ct);
                 return Results.Ok(dto);
             });
 

--- a/Tycoon.Backend.Application/Abstractions/IPresignedStorage.cs
+++ b/Tycoon.Backend.Application/Abstractions/IPresignedStorage.cs
@@ -1,0 +1,16 @@
+namespace Tycoon.Backend.Application.Abstractions
+{
+    /// <summary>
+    /// Implemented by storage backends that support client-side direct uploads
+    /// via time-limited presigned PUT URLs (e.g. MinIO, S3).
+    /// </summary>
+    public interface IPresignedStorage
+    {
+        /// <summary>
+        /// Generates a presigned HTTP PUT URL that an external client (e.g. browser)
+        /// can use to upload a file directly to the storage backend without routing
+        /// the bytes through the API server.
+        /// </summary>
+        Task<string> GetPresignedPutUrlAsync(string key, string contentType, TimeSpan expiry, CancellationToken ct = default);
+    }
+}

--- a/Tycoon.Backend.Application/Media/MediaService.cs
+++ b/Tycoon.Backend.Application/Media/MediaService.cs
@@ -1,16 +1,31 @@
-﻿using Tycoon.Shared.Contracts.Dtos;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Shared.Contracts.Dtos;
 
 namespace Tycoon.Backend.Application.Media
 {
-    public sealed class MediaService
+    public sealed class MediaService(IObjectStorage storage)
     {
-        // For now: local uploads. Later: return S3/Cloudflare R2 presigned URLs.
-        public UploadIntentDto CreateUploadIntent(CreateUploadIntentRequest req)
+        private static readonly TimeSpan UploadExpiry = TimeSpan.FromMinutes(10);
+
+        public async Task<UploadIntentDto> CreateUploadIntentAsync(CreateUploadIntentRequest req, CancellationToken ct = default)
         {
             var now = DateTimeOffset.UtcNow;
             var assetKey = $"uploads/{now:yyyyMMdd}/{Guid.NewGuid():N}_{Sanitize(req.FileName)}";
-            var uploadUrl = $"/admin/media/upload/{Uri.EscapeDataString(assetKey)}";
-            return new UploadIntentDto(assetKey, uploadUrl, now.AddMinutes(10));
+
+            string uploadUrl;
+            if (storage is IPresignedStorage presigned)
+            {
+                // MinIO (or any S3-compatible backend): browser uploads directly,
+                // bypassing the API. The URL expires in UploadExpiry.
+                uploadUrl = await presigned.GetPresignedPutUrlAsync(assetKey, req.ContentType, UploadExpiry, ct);
+            }
+            else
+            {
+                // Local dev / tests: fall back to the API-proxied upload endpoint.
+                uploadUrl = $"/admin/media/upload/{Uri.EscapeDataString(assetKey)}";
+            }
+
+            return new UploadIntentDto(assetKey, uploadUrl, now.Add(UploadExpiry));
         }
 
         private static string Sanitize(string name)

--- a/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
+++ b/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
@@ -4,7 +4,7 @@ using Tycoon.Backend.Application.Abstractions;
 
 namespace Tycoon.Backend.Infrastructure.Storage
 {
-    public sealed class MinioObjectStorage : IObjectStorage
+    public sealed class MinioObjectStorage : IObjectStorage, IPresignedStorage
     {
         private readonly IMinioClient _client;
         private readonly MinioOptions _options;
@@ -34,6 +34,32 @@ namespace Tycoon.Backend.Infrastructure.Storage
             var host = _options.PublicEndpoint ?? _options.Endpoint;
             var scheme = _options.UseSSL ? "https" : "http";
             return $"{scheme}://{host}/{_options.Bucket}/{key}";
+        }
+
+        public async Task<string> GetPresignedPutUrlAsync(string key, string contentType, TimeSpan expiry, CancellationToken ct = default)
+        {
+            await EnsureBucketExistsAsync(ct);
+
+            var args = new PresignedPutObjectArgs()
+                .WithBucket(_options.Bucket)
+                .WithObject(key)
+                .WithExpiry((int)expiry.TotalSeconds);
+
+            var internalUrl = await _client.PresignedPutObjectAsync(args);
+
+            // Rewrite the internal host (minio:9000) to the public-facing host when
+            // PublicEndpoint is configured — the browser calling the URL needs a host
+            // it can reach, not the internal container hostname.
+            if (!string.IsNullOrWhiteSpace(_options.PublicEndpoint) &&
+                Uri.TryCreate(internalUrl, UriKind.Absolute, out var parsed))
+            {
+                var publicScheme = _options.UseSSL ? "https" : "http";
+                internalUrl = internalUrl.Replace(
+                    $"{parsed.Scheme}://{parsed.Host}:{parsed.Port}",
+                    $"{publicScheme}://{_options.PublicEndpoint}");
+            }
+
+            return internalUrl;
         }
 
         private async Task EnsureBucketExistsAsync(CancellationToken ct)


### PR DESCRIPTION
…resigned PUT URLs

Routing fix:
- AdminMediaEndpoints.Map(RouteGroupBuilder admin) was calling admin.MapGroup("/admin/media"), producing inaccessible /admin/admin/media/* routes (same pattern fixed earlier in AdminAnalytics and AdminGameEvents)
- Changed to admin.MapGroup("/media") → resolves to /admin/media/* correctly

IPresignedStorage interface (Tycoon.Backend.Application/Abstractions/):
- New interface with GetPresignedPutUrlAsync(key, contentType, expiry, ct)
- Implemented by storage backends that support client-side direct uploads without routing bytes through the API server

MinioObjectStorage now implements IPresignedStorage:
- GetPresignedPutUrlAsync uses Minio SDK PresignedPutObjectArgs
- Rewrites the internal container host to PublicEndpoint when configured, so the URL is reachable by the browser (not just the internal network)

MediaService upgraded to async + presigned-URL aware:
- CreateUploadIntentAsync(req, ct) replaces CreateUploadIntent(req)
- Checks storage is IPresignedStorage at runtime:
  - MinIO configured → returns presigned PUT URL (browser uploads directly)
  - LocalObjectStorage / tests → falls back to /admin/media/upload/{key}
- IObjectStorage injected via primary constructor; DI unchanged (already singleton)

Tests (AdminMediaTests.cs):
- Fixed indentation / whitespace noise in existing tests
- Added dto.ExpiresAtUtc assertion on the intent response
- Added comment explaining why UploadUrl is the local path in test context

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc