### PR TITLE
fix(docker): fix Dockerfile.dashboard build failures

### DIFF
--- a/docker/Dockerfile.dashboard
+++ b/docker/Dockerfile.dashboard
@@ -1,8 +1,14 @@
 ARG BUILD_CONFIGURATION=Release
 
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
+# Copy Central Package Management files first (rarely change)
+COPY ["Directory.Build.props", "./"]
+COPY ["Directory.Packages.props", "./"]
+
+# Copy project files for restore layer caching
 COPY ["Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj", "Tycoon.OperatorDashboard/"]
 COPY ["Tycoon.ServiceDefaults/Tycoon.ServiceDefaults.csproj", "Tycoon.ServiceDefaults/"]
 COPY ["Tycoon.Shared.Contracts/Tycoon.Shared.Contracts.csproj", "Tycoon.Shared.Contracts/"]
@@ -13,11 +19,12 @@ RUN dotnet restore "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj"
 COPY . .
 
 RUN dotnet build "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj" \
-    -c "${BUILD_CONFIGURATION}" -o /app/build
+    -c "${BUILD_CONFIGURATION}" -o /app/build --no-restore
 
 FROM build AS publish
+ARG BUILD_CONFIGURATION=Release
 RUN dotnet publish "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj" \
-    -c "${BUILD_CONFIGURATION}" -o /app/publish /p:UseAppHost=false
+    -c "${BUILD_CONFIGURATION}" -o /app/publish /p:UseAppHost=false --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app


### PR DESCRIPTION
Three bugs in Dockerfile.dashboard vs the working Dockerfile.api pattern:

1. Directory.Build.props and Directory.Packages.props were not copied before dotnet restore. These files enable Central Package Management (CPM) — without them, dotnet restore cannot resolve package versions and the build fails.

2. ARG BUILD_CONFIGURATION was declared before FROM (global scope) but never re-declared inside the build stage. Docker ARGs before FROM are not available inside stages without an explicit ARG redeclaration. This caused ${BUILD_CONFIGURATION} to expand to an empty string, making dotnet build receive -c "" which is invalid.

3. --no-restore was missing from the build and publish steps. After an explicit dotnet restore, --no-restore prevents a redundant second restore that would run without the properly layered CPM files and could produce different results.

Fix aligns Dockerfile.dashboard with the same pattern already used in Dockerfile.api.

https://claude.ai/code/session_01F2FgUZk38wETNHKBM23Nnc