### PR TITLE
Add Traefik reverse proxy and tighten CORS

### DIFF
--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -446,10 +446,13 @@ if (app.Environment.IsDevelopment())
 app.UseMiddleware<ExceptionMiddleware>();
 app.UseAuthentication();
 app.UseAuthorization();
+var allowedOrigins = builder.Configuration
+    .GetSection("Cors:AllowedOrigins").Get<string[]>() ?? [];
 app.UseCors(c => c.AllowAnyHeader()
                   .AllowAnyMethod()
                   .AllowCredentials()
-                  .SetIsOriginAllowed(_ => true));
+                  .SetIsOriginAllowedToAllowWildcardSubdomains()
+                  .WithOrigins(allowedOrigins));
 app.UseWebSockets();
 app.UseRateLimiter();
 app.UseMiddleware<AdminOpsKeyMiddleware>();

--- a/Tycoon.Backend.Api/appsettings.json
+++ b/Tycoon.Backend.Api/appsettings.json
@@ -35,6 +35,14 @@
     "DailyWriteAlias": "tycoon-qa-daily-rollups",
     "PlayerDailyWriteAlias": "tycoon-qa-player-daily-rollups"
   },
+  "Cors": {
+    "AllowedOrigins": [
+      "http://localhost:8200",
+      "https://localhost:8200",
+      "http://localhost:63033",
+      "https://localhost:63033"
+    ]
+  },
   "AdminOps": {
     "Enabled": true,
     "Header": "X-Admin-Ops-Key",

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -82,3 +82,13 @@ SUPER_ADMIN_HANDLE=superadmin
 
 # --- Logging ---
 LOG_LEVEL=Information
+
+# --- Traefik Reverse Proxy ---
+# Dev: Traefik listens on port 80 (dashboard on 8080). Direct service ports remain accessible as fallback.
+# Prod: Set DOMAIN and ACME_EMAIL; Traefik handles HTTPS via Let's Encrypt.
+#   Run with: docker compose -f docker/compose.yml -f docker/compose.prod.yml up -d
+TRAEFIK_HTTP_PORT=80
+TRAEFIK_DASHBOARD_PORT=8080
+# Production-only — required when using compose.prod.yml:
+DOMAIN=yourdomain.com
+ACME_EMAIL=admin@yourdomain.com

--- a/docker/compose.prod.yml
+++ b/docker/compose.prod.yml
@@ -1,9 +1,67 @@
 # Production overrides:
 # - No dev UIs
-# - Only expose API to host (infra stays private inside the compose network)
+# - All traffic enters through Traefik (ports 80 + 443); individual services not exposed to host
+# - Automatic HTTPS via Let's Encrypt (set DOMAIN and ACME_EMAIL in .env)
 # - Tighter defaults for resources and logging
 
 services:
+  # --------------------------------
+  # Traefik — production HTTPS mode
+  # --------------------------------
+  traefik:
+    command:
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=tycoon-net"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.websecure.address=:443"
+      - "--certificatesresolvers.le.acme.email=${ACME_EMAIL:?ACME_EMAIL is required in prod}"
+      - "--certificatesresolvers.le.acme.storage=/letsencrypt/acme.json"
+      - "--certificatesresolvers.le.acme.tlschallenge=true"
+      - "--log.level=WARN"
+    ports:
+      - "80:80"
+      - "443:443"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  # backend-api — no direct port exposure in prod; route through Traefik with HTTPS labels
+  backend-api:
+    ports: []
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.backend-api.rule=Host(`api.${DOMAIN:?DOMAIN is required in prod}`)"
+      - "traefik.http.routers.backend-api.entrypoints=websecure"
+      - "traefik.http.routers.backend-api.tls.certresolver=le"
+      - "traefik.http.services.backend-api.loadbalancer.server.port=5000"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
+  # operator-dashboard — no direct port exposure in prod; route through Traefik with HTTPS labels
+  operator-dashboard:
+    ports: []
+    environment:
+      ASPNETCORE_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT:-Production}"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.operator-dashboard.rule=Host(`${DOMAIN:?DOMAIN is required in prod}`)"
+      - "traefik.http.routers.operator-dashboard.entrypoints=websecure"
+      - "traefik.http.routers.operator-dashboard.tls.certresolver=le"
+      - "traefik.http.services.operator-dashboard.loadbalancer.server.port=8200"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "5"
+
   postgres:
     # In prod, avoid exposing DB to the host unless required
     ports: []
@@ -85,32 +143,6 @@ services:
 
   grafana:
     profiles: ["disabled"]
-
-  # Backend API - exposed to host in production
-  backend-api:
-    # Expose only the API
-    ports:
-      - "${BACKEND_HTTP_PORT:-5000}:5000"
-    environment:
-      ASPNETCORE_ENVIRONMENT: "${ASPNETCORE_ENVIRONMENT:-Production}"
-      ASPNETCORE_URLS: "http://+:5000"
-    depends_on:
-      postgres:
-        condition: service_healthy
-      mongodb:
-        condition: service_healthy
-      redis:
-        condition: service_healthy
-      elasticsearch:
-        condition: service_healthy
-      rabbitmq:
-        condition: service_healthy
-    restart: unless-stopped
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "10m"
-        max-file: "5"
 
   # Migrations should be an explicit step in prod (run once per deploy)
   migration:

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -258,6 +258,29 @@ services:
       networks: [tycoon-net]
 
   # ================================
+  # Reverse Proxy
+  # ================================
+  traefik:
+    image: traefik:v3.2
+    container_name: tycoon_traefik
+    restart: unless-stopped
+    command:
+      - "--api.dashboard=true"
+      - "--api.insecure=true"
+      - "--providers.docker=true"
+      - "--providers.docker.exposedbydefault=false"
+      - "--providers.docker.network=tycoon-net"
+      - "--entrypoints.web.address=:80"
+      - "--log.level=INFO"
+    ports:
+      - "${TRAEFIK_HTTP_PORT:-80}:80"
+      - "${TRAEFIK_DASHBOARD_PORT:-8080}:8080"
+    volumes:
+      - "/var/run/docker.sock:/var/run/docker.sock:ro"
+      - letsencrypt:/letsencrypt
+    networks: [tycoon-net]
+
+  # ================================
   # Backend Services
   # ================================
   migration:
@@ -378,6 +401,9 @@ services:
       Observability__ServiceName: "Tycoon.Backend.Api"
       Serilog__MinimumLevel: "${LOG_LEVEL:-Information}"
       DataProtection__KeysPath: "${DATA_PROTECTION_KEYS_PATH:-/tmp/tycoon-dpkeys}"
+      # Comma-separated origins allowed by CORS (e.g. for mobile clients calling the API directly)
+      Cors__AllowedOrigins__0: "${CORS_ORIGIN_0:-http://localhost:8200}"
+      Cors__AllowedOrigins__1: "${CORS_ORIGIN_1:-}"
     depends_on:
       postgres:
         condition: service_healthy
@@ -394,6 +420,15 @@ services:
       migration:
         condition: service_completed_successfully
     networks: [tycoon-net]
+    labels:
+      - "traefik.enable=true"
+      # Route /api/* to the backend; strip the /api prefix before forwarding
+      - "traefik.http.routers.backend-api.rule=PathPrefix(`/api`)"
+      - "traefik.http.routers.backend-api.entrypoints=web"
+      - "traefik.http.routers.backend-api.priority=10"
+      - "traefik.http.services.backend-api.loadbalancer.server.port=5000"
+      - "traefik.http.middlewares.backend-api-strip.stripprefix.prefixes=/api"
+      - "traefik.http.routers.backend-api.middlewares=backend-api-strip"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:5000/healthz"]
       interval: 30s
@@ -462,6 +497,13 @@ services:
       backend-api:
         condition: service_healthy
     networks: [tycoon-net]
+    labels:
+      - "traefik.enable=true"
+      # Route everything else to the operator dashboard (lowest priority)
+      - "traefik.http.routers.operator-dashboard.rule=PathPrefix(`/`)"
+      - "traefik.http.routers.operator-dashboard.entrypoints=web"
+      - "traefik.http.routers.operator-dashboard.priority=1"
+      - "traefik.http.services.operator-dashboard.loadbalancer.server.port=8200"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8200/health"]
       interval: 30s
@@ -491,3 +533,4 @@ volumes:
   prometheus_data:
   grafana_data:
   dashboard_dp_keys:
+  letsencrypt:


### PR DESCRIPTION
Dev (compose.yml):
- Add Traefik v3.2 service on port 80 (dashboard on 8080)
- Route /api/* → backend-api (strip /api prefix before forwarding)
- Route /* → operator-dashboard (lower priority catch-all)
- Direct service ports remain accessible as fallback
- Add letsencrypt volume for prod cert storage

Prod (compose.prod.yml):
- Override Traefik with HTTPS + Let's Encrypt ACME (TLS challenge)
- HTTP → HTTPS redirect on all entrypoints
- Host-based routing: api.<DOMAIN> → backend-api, <DOMAIN> → dashboard
- Remove direct port exposure for backend-api and operator-dashboard

CORS (Program.cs + appsettings.json):
- Replace wildcard SetIsOriginAllowed with explicit AllowedOrigins list
- Default origins cover localhost dashboard ports; override via env vars Cors__AllowedOrigins__0 / Cors__AllowedOrigins__1 in compose

.env.example:
- Document TRAEFIK_HTTP_PORT, TRAEFIK_DASHBOARD_PORT, DOMAIN, ACME_EMAIL

https://claude.ai/code/session_01K5mynMMCjV7aCpUHubW767