### PR TITLE
Fix API Unreachable: resolve transient AdminApiClient token bug

### DIFF
--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -31,7 +31,12 @@ builder.Services.AddAuthorization();
 builder.Services.AddHttpContextAccessor();
 
 builder.Services.AddSingleton<TokenStore>();
+// BearerTokenStore is scoped per Blazor circuit so every AdminApiClient instance
+// in the same circuit shares the same token (fixes the transient-instance token bug).
+builder.Services.AddScoped<BearerTokenStore>();
 builder.Services.AddScoped<AdminAuthService>();
+// Transient handler — DI creates one per HttpClient request; reads from scoped BearerTokenStore.
+builder.Services.AddTransient<BearerTokenHandler>();
 
 // Typed HttpClient that forwards the admin JWT + ops key to tycoon-api.
 // Aspire service discovery resolves "http://tycoon-api" via services__tycoon-api__http__0.
@@ -47,7 +52,8 @@ builder.Services.AddHttpClient<AdminApiClient>(client =>
     var opsKey = builder.Configuration["AdminOps:Key"] ?? string.Empty;
     if (!string.IsNullOrEmpty(opsKey))
         client.DefaultRequestHeaders.TryAddWithoutValidation("X-Admin-Ops-Key", opsKey);
-});
+})
+.AddHttpMessageHandler<BearerTokenHandler>();
 
 var app = builder.Build();
 

--- a/Tycoon.OperatorDashboard/Services/AdminAuthService.cs
+++ b/Tycoon.OperatorDashboard/Services/AdminAuthService.cs
@@ -8,6 +8,7 @@ namespace Tycoon.OperatorDashboard.Services;
 public sealed class AdminAuthService(
     AdminApiClient api,
     TokenStore tokens,
+    BearerTokenStore bearerTokenStore,
     IHttpContextAccessor httpCtx,
     AuthenticationStateProvider authStateProvider)
 {
@@ -48,6 +49,7 @@ public sealed class AdminAuthService(
         var userId = httpCtx.HttpContext?.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         if (userId is not null) tokens.Remove(userId);
         api.ClearToken();
+        bearerTokenStore.AccessToken = null;
         await httpCtx.HttpContext!.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
     }
 
@@ -96,6 +98,7 @@ public sealed class AdminAuthService(
         }
 
         api.SetToken(entry.AccessToken);
+        bearerTokenStore.AccessToken = entry.AccessToken;
         return true;
     }
 }

--- a/Tycoon.OperatorDashboard/Services/BearerTokenHandler.cs
+++ b/Tycoon.OperatorDashboard/Services/BearerTokenHandler.cs
@@ -1,0 +1,23 @@
+using System.Net.Http.Headers;
+
+namespace Tycoon.OperatorDashboard.Services;
+
+/// <summary>
+/// DelegatingHandler that injects the current Blazor circuit's Bearer token into every
+/// outgoing AdminApiClient request. By reading from the scoped BearerTokenStore rather
+/// than from HttpClient.DefaultRequestHeaders, all AdminApiClient instances within the
+/// same circuit automatically use the same token — regardless of how many transient
+/// instances DI creates.
+/// </summary>
+public sealed class BearerTokenHandler(BearerTokenStore tokenStore) : DelegatingHandler
+{
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken ct)
+    {
+        if (!string.IsNullOrEmpty(tokenStore.AccessToken))
+            request.Headers.Authorization =
+                new AuthenticationHeaderValue("Bearer", tokenStore.AccessToken);
+
+        return base.SendAsync(request, ct);
+    }
+}

--- a/Tycoon.OperatorDashboard/Services/BearerTokenStore.cs
+++ b/Tycoon.OperatorDashboard/Services/BearerTokenStore.cs
@@ -1,0 +1,17 @@
+namespace Tycoon.OperatorDashboard.Services;
+
+/// <summary>
+/// Scoped per Blazor Server circuit. Holds the current user's Bearer token so every
+/// AdminApiClient instance within the same circuit shares the same token automatically.
+///
+/// The root cause this solves: AddHttpClient registers AdminApiClient as transient, meaning
+/// Dashboard.razor's @inject AdminApiClient and AdminAuthService's constructor injection
+/// receive two different instances. SetToken() on one instance never affects the other.
+/// This store is injected into BearerTokenHandler (which runs on every request) and into
+/// AdminAuthService (which writes the token after login/refresh), guaranteeing both see
+/// the same value for the lifetime of the circuit.
+/// </summary>
+public sealed class BearerTokenStore
+{
+    public string? AccessToken { get; set; }
+}


### PR DESCRIPTION
Root cause: AddHttpClient<AdminApiClient> registers AdminApiClient as transient. Dashboard.razor (@inject AdminApiClient Api) and AdminAuthService (constructor injection) receive two different instances. TryAttachTokenAsync called api.SetToken() on AdminAuthService's instance only — the Dashboard's Api.GetConfigAsync() ran with no Bearer token, returned 401, and _apiConnected was set to false ("API Unreachable").

Fix: introduce a scoped BearerTokenStore + BearerTokenHandler pipeline:
- BearerTokenStore (scoped per Blazor circuit) holds the current token
- BearerTokenHandler (DelegatingHandler) reads from BearerTokenStore and injects the Authorization header into every outgoing request, regardless of which AdminApiClient instance DI resolved
- AdminAuthService writes to BearerTokenStore on login/refresh and clears it on logout
- BearerTokenHandler is registered with .AddHttpMessageHandler so all AdminApiClient instances in the circuit share the same token

https://claude.ai/code/session_01K5mynMMCjV7aCpUHubW767