### PR TITLE
Add database-backed admin email ACL management system

### DIFF
--- a/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
@@ -3,12 +3,13 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
 using System.Diagnostics;
-using Microsoft.Extensions.Configuration;
+using Microsoft.EntityFrameworkCore;
 using Tycoon.Backend.Api.Contracts;
 using Tycoon.Backend.Api.Observability;
 using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Application.Auth;
+using Tycoon.Backend.Domain.Entities;
 using Tycoon.Shared.Contracts.Dtos;
 
 namespace Tycoon.Backend.Api.Features.AdminAuth;
@@ -37,7 +38,6 @@ public static class AdminAuthEndpoints
     private static async Task<IResult> Login(
         [FromBody] AdminLoginRequest request,
         IAuthService authService,
-        IConfiguration configuration,
         IAppDb db,
         CancellationToken ct)
     {
@@ -54,7 +54,7 @@ public static class AdminAuthEndpoints
         {
             var auth = await authService.AdminLoginAsync(request.Email, request.Password, deviceId: "admin-web");
 
-            if (!IsAdminEmail(request.Email, configuration))
+            if (!await IsAdminEmailAsync(request.Email, db, ct))
             {
                 await AdminSecurityAudit.WriteAsync(db, "admin_auth_login", "forbidden", new { email = request.Email, reason = "email_not_allowlisted" }, ct);
                 AdminSecurityMetrics.RecordAuth("login", "forbidden", sw);
@@ -135,14 +135,22 @@ public static class AdminAuthEndpoints
         ));
     }
 
-    private static bool IsAdminEmail(string email, IConfiguration configuration)
+    private static async Task<bool> IsAdminEmailAsync(string email, IAppDb db, CancellationToken ct)
     {
-        var allowedEmails = configuration.GetSection("AdminAuth:AllowedEmails").Get<string[]>() ?? [];
-        if (allowedEmails.Length == 0)
-        {
-            return true;
-        }
+        var normalized = email.Trim().ToLowerInvariant();
 
-        return allowedEmails.Contains(email, StringComparer.OrdinalIgnoreCase);
+        // Blocklist always wins
+        var isBlocked = await db.AdminEmailAcls.AsNoTracking()
+            .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Block, ct);
+        if (isBlocked) return false;
+
+        // If no allowlist entries exist, permit all (open access)
+        var hasAllowEntries = await db.AdminEmailAcls.AsNoTracking()
+            .AnyAsync(e => e.ListType == AdminAclListType.Allow, ct);
+        if (!hasAllowEntries) return true;
+
+        // Email must be on the allowlist
+        return await db.AdminEmailAcls.AsNoTracking()
+            .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Allow, ct);
     }
 }

--- a/Tycoon.Backend.Api/Features/AdminEmailAcl/AdminEmailAclEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminEmailAcl/AdminEmailAclEndpoints.cs
@@ -1,0 +1,171 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Api.Security;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.AdminEmailAcl;
+
+public static class AdminEmailAclEndpoints
+{
+    public static void Map(RouteGroupBuilder admin)
+    {
+        var g = admin.MapGroup("/email-acl").WithTags("Admin/EmailAcl").WithOpenApi();
+
+        // List all ACL entries (paginated, filterable by list type)
+        g.MapGet("/", async (
+            [FromQuery] string? listType,
+            [FromQuery] int page,
+            [FromQuery] int pageSize,
+            IAppDb db,
+            CancellationToken ct) =>
+        {
+            page = page <= 0 ? 1 : page;
+            pageSize = pageSize <= 0 ? 25 : Math.Clamp(pageSize, 1, 200);
+
+            var q = db.AdminEmailAcls.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(listType) &&
+                Enum.TryParse<AdminAclListType>(listType, ignoreCase: true, out var parsed))
+            {
+                q = q.Where(e => e.ListType == parsed);
+            }
+
+            var totalItems = await q.CountAsync(ct);
+            var items = await q.OrderBy(e => e.NormalizedEmail)
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Select(e => ToDto(e))
+                .ToListAsync(ct);
+            var totalPages = totalItems == 0 ? 0 : (int)Math.Ceiling(totalItems / (double)pageSize);
+
+            return Results.Ok(new AdminEmailAclListResponse(items, page, pageSize, totalItems, totalPages));
+        })
+        .RequireAuthorization(AdminPolicies.AdminOpsPolicy);
+
+        // Get a single entry by ID
+        g.MapGet("/{id:guid}", async (Guid id, IAppDb db, CancellationToken ct) =>
+        {
+            var entry = await db.AdminEmailAcls.AsNoTracking()
+                .FirstOrDefaultAsync(e => e.Id == id, ct);
+
+            return entry is null
+                ? AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "ACL entry not found.")
+                : Results.Ok(ToDto(entry));
+        })
+        .RequireAuthorization(AdminPolicies.AdminOpsPolicy);
+
+        // Create a new ACL entry
+        g.MapPost("/", async (
+            [FromBody] CreateAdminEmailAclRequest request,
+            HttpContext httpContext,
+            IAppDb db,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(request.Email) || !request.Email.Contains('@'))
+                return AdminApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", "A valid email address is required.");
+
+            if (!Enum.TryParse<AdminAclListType>(request.ListType, ignoreCase: true, out var listType))
+                return AdminApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", "ListType must be 'Allow' or 'Block'.");
+
+            if (!Enum.TryParse<AdminRole>(request.Role, ignoreCase: true, out var role))
+                return AdminApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", "Role must be 'Viewer', 'Admin', or 'SuperAdmin'.");
+
+            var normalized = request.Email.Trim().ToLowerInvariant();
+            var existing = await db.AdminEmailAcls.FirstOrDefaultAsync(e => e.NormalizedEmail == normalized, ct);
+            if (existing is not null)
+                return AdminApiResponses.Error(StatusCodes.Status409Conflict, "CONFLICT", "An ACL entry for this email already exists.");
+
+            var actor = httpContext.User.FindFirst("sub")?.Value
+                        ?? httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                        ?? "unknown";
+
+            var entry = new Domain.Entities.AdminEmailAcl(request.Email, listType, role, actor, request.Notes);
+            db.AdminEmailAcls.Add(entry);
+
+            await AdminSecurityAudit.WriteAsync(db, "admin_email_acl_create", "success", new
+            {
+                email = normalized,
+                listType = listType.ToString(),
+                role = role.ToString(),
+                actor
+            }, ct);
+
+            return Results.Created($"/admin/email-acl/{entry.Id}", ToDto(entry));
+        })
+        .RequireAuthorization(AdminPolicies.SuperAdminPolicy);
+
+        // Update an existing ACL entry
+        g.MapPatch("/{id:guid}", async (
+            Guid id,
+            [FromBody] UpdateAdminEmailAclRequest request,
+            HttpContext httpContext,
+            IAppDb db,
+            CancellationToken ct) =>
+        {
+            var entry = await db.AdminEmailAcls.FirstOrDefaultAsync(e => e.Id == id, ct);
+            if (entry is null)
+                return AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "ACL entry not found.");
+
+            if (!Enum.TryParse<AdminAclListType>(request.ListType, ignoreCase: true, out var listType))
+                return AdminApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", "ListType must be 'Allow' or 'Block'.");
+
+            if (!Enum.TryParse<AdminRole>(request.Role, ignoreCase: true, out var role))
+                return AdminApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", "Role must be 'Viewer', 'Admin', or 'SuperAdmin'.");
+
+            var actor = httpContext.User.FindFirst("sub")?.Value
+                        ?? httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                        ?? "unknown";
+
+            entry.Update(listType, role, request.Notes);
+
+            await AdminSecurityAudit.WriteAsync(db, "admin_email_acl_update", "success", new
+            {
+                entryId = entry.Id,
+                email = entry.NormalizedEmail,
+                listType = listType.ToString(),
+                role = role.ToString(),
+                actor
+            }, ct);
+
+            return Results.Ok(ToDto(entry));
+        })
+        .RequireAuthorization(AdminPolicies.SuperAdminPolicy);
+
+        // Delete an ACL entry
+        g.MapDelete("/{id:guid}", async (
+            Guid id,
+            HttpContext httpContext,
+            IAppDb db,
+            CancellationToken ct) =>
+        {
+            var entry = await db.AdminEmailAcls.FirstOrDefaultAsync(e => e.Id == id, ct);
+            if (entry is null)
+                return AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "ACL entry not found.");
+
+            var actor = httpContext.User.FindFirst("sub")?.Value
+                        ?? httpContext.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value
+                        ?? "unknown";
+
+            db.AdminEmailAcls.Remove(entry);
+
+            await AdminSecurityAudit.WriteAsync(db, "admin_email_acl_delete", "success", new
+            {
+                entryId = entry.Id,
+                email = entry.NormalizedEmail,
+                actor
+            }, ct);
+
+            return Results.NoContent();
+        })
+        .RequireAuthorization(AdminPolicies.SuperAdminPolicy);
+    }
+
+    private static AdminEmailAclEntryDto ToDto(Domain.Entities.AdminEmailAcl e)
+        => new(e.Id, e.Email, e.ListType.ToString(), e.Role.ToString(), e.Notes, e.AddedBy, e.CreatedAtUtc, e.UpdatedAtUtc);
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -30,6 +30,7 @@ using Tycoon.Backend.Api.Features.AdminMedia;
 using Tycoon.Backend.Api.Features.AdminModeration;
 using Tycoon.Backend.Api.Features.AdminNotifications;
 using Tycoon.Backend.Api.Features.AdminConfig;
+using Tycoon.Backend.Api.Features.AdminEmailAcl;
 using Tycoon.Backend.Api.Features.AdminPowerups;
 using Tycoon.Backend.Api.Features.AdminQuestions;
 using Tycoon.Backend.Api.Features.AdminSeasons;
@@ -726,6 +727,7 @@ AdminAntiCheatAnalyticsEndpoints.Map(admin);
 AdminPartyAntiCheatEndpoints.Map(admin);
 AdminSeasonRewardsEndpoints.Map(admin);
 AdminSeasonLifecycleEndpoints.Map(admin);
+AdminEmailAclEndpoints.Map(admin);
 
 // Startup logging
 app.Logger.LogInformation("🚀 Tycoon Backend API starting...");

--- a/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
+++ b/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
@@ -4,8 +4,11 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Entities;
 
 namespace Tycoon.Backend.Api.Security
 {
@@ -182,24 +185,37 @@ namespace Tycoon.Backend.Api.Security
                         : ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
                 }
 
-                // Filter blank entries: compose.yml uses "${SUPER_ADMIN_EMAIL:-}" which
-                // injects an empty string when the env var is unset, turning a "no allowlist"
-                // config into a single-empty-string allowlist that blocks every admin.
-                var allowedEmails = (cfg.GetSection("AdminAuth:AllowedEmails").Get<string[]>() ?? [])
-                    .Where(e => !string.IsNullOrWhiteSpace(e))
-                    .ToArray();
                 var email = http.User.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value
                             ?? http.User.FindFirst("email")?.Value;
+                var normalizedEmail = email?.Trim().ToLowerInvariant();
 
-                if (allowedEmails.Length > 0 && (string.IsNullOrWhiteSpace(email) || !allowedEmails.Contains(email, StringComparer.OrdinalIgnoreCase)))
+                // Check DB-backed email ACL. Blocklist takes precedence.
+                var db = http.RequestServices.GetRequiredService<IAppDb>();
+                var aclEntry = string.IsNullOrWhiteSpace(normalizedEmail)
+                    ? null
+                    : await db.AdminEmailAcls.AsNoTracking()
+                        .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail, http.RequestAborted);
+
+                if (aclEntry is not null && aclEntry.ListType == AdminAclListType.Block)
                 {
-                    logger.LogWarning("AdminRoleClaims email allowlist FAILED for {Method} {Path}: email={Email}, allowlistCount={Count}",
-                        http.Request.Method, http.Request.Path, email ?? "(no email claim)", allowedEmails.Length);
+                    logger.LogWarning("AdminRoleClaims email BLOCKED for {Method} {Path}: email={Email}",
+                        http.Request.Method, http.Request.Path, normalizedEmail);
+                    return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is blocked.");
+                }
+
+                // If ACL entries exist, require the email to be on the allowlist
+                var hasAclEntries = await db.AdminEmailAcls.AsNoTracking()
+                    .AnyAsync(e => e.ListType == AdminAclListType.Allow, http.RequestAborted);
+
+                if (hasAclEntries && (aclEntry is null || aclEntry.ListType != AdminAclListType.Allow))
+                {
+                    logger.LogWarning("AdminRoleClaims email allowlist FAILED for {Method} {Path}: email={Email}",
+                        http.Request.Method, http.Request.Path, normalizedEmail ?? "(no email claim)");
                     return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is not allowlisted.");
                 }
 
-                logger.LogDebug("AdminRoleClaims PASSED for {Method} {Path}, email={Email}",
-                    http.Request.Method, http.Request.Path, email ?? "(none)");
+                logger.LogDebug("AdminRoleClaims PASSED for {Method} {Path}, email={Email}, role={AclRole}",
+                    http.Request.Method, http.Request.Path, normalizedEmail ?? "(none)", aclEntry?.Role.ToString() ?? "default");
 
                 return await next(context);
             });

--- a/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
+++ b/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
@@ -1,9 +1,10 @@
-﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Tycoon.Backend.Api.Contracts;
 
 namespace Tycoon.Backend.Api.Security
@@ -28,11 +29,13 @@ namespace Tycoon.Backend.Api.Security
     {
         private readonly RequestDelegate _next;
         private readonly IConfiguration _cfg;
+        private readonly ILogger<AdminOpsKeyMiddleware> _logger;
 
-        public AdminOpsKeyMiddleware(RequestDelegate next, IConfiguration cfg)
+        public AdminOpsKeyMiddleware(RequestDelegate next, IConfiguration cfg, ILogger<AdminOpsKeyMiddleware> logger)
         {
             _next = next;
             _cfg = cfg;
+            _logger = logger;
         }
 
         public async Task Invoke(HttpContext ctx)
@@ -54,7 +57,7 @@ namespace Tycoon.Backend.Api.Security
                 return;
             }
 
-            var validation = ValidateOpsKey(ctx, _cfg);
+            var validation = ValidateOpsKey(ctx, _cfg, _logger);
             if (validation is not null)
             {
                 await validation.ExecuteAsync(ctx);
@@ -64,7 +67,7 @@ namespace Tycoon.Backend.Api.Security
             await _next(ctx);
         }
 
-        internal static IResult? ValidateOpsKey(HttpContext ctx, IConfiguration cfg)
+        internal static IResult? ValidateOpsKey(HttpContext ctx, IConfiguration cfg, ILogger? logger = null)
         {
             var headerName = cfg["AdminOps:Header"];
             if (string.IsNullOrWhiteSpace(headerName))
@@ -72,15 +75,29 @@ namespace Tycoon.Backend.Api.Security
 
             var expectedKey = cfg["AdminOps:Key"] ?? string.Empty;
             if (string.IsNullOrWhiteSpace(expectedKey))
+            {
+                logger?.LogWarning("AdminOpsKey: AdminOps:Key is not configured in settings");
                 return ApiResponses.Error(StatusCodes.Status503ServiceUnavailable, "SERVICE_UNAVAILABLE", "AdminOps key not configured.");
+            }
 
             if (!ctx.Request.Headers.TryGetValue(headerName, out var provided) ||
                 string.IsNullOrWhiteSpace(provided))
+            {
+                logger?.LogWarning("AdminOpsKey: {HeaderName} header missing or empty on {Method} {Path}",
+                    headerName, ctx.Request.Method, ctx.Request.Path);
                 return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Missing admin ops key.");
+            }
 
             if (!string.Equals(provided.ToString(), expectedKey, StringComparison.Ordinal))
+            {
+                var providedStr = provided.ToString();
+                var suffix = providedStr.Length >= 4 ? providedStr[^4..] : "****";
+                logger?.LogWarning("AdminOpsKey: provided key does not match expected key on {Method} {Path} (provided ends with ...{KeySuffix})",
+                    ctx.Request.Method, ctx.Request.Path, suffix);
                 return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Invalid admin ops key.");
+            }
 
+            logger?.LogDebug("AdminOpsKey: validated successfully for {Method} {Path}", ctx.Request.Method, ctx.Request.Path);
             return null;
         }
     }
@@ -100,7 +117,9 @@ namespace Tycoon.Backend.Api.Security
                 var enabled = cfg.GetValue("AdminOps:Enabled", true);
                 if (!enabled) return await next(context);
 
-                var validation = AdminOpsKeyMiddleware.ValidateOpsKey(http, cfg);
+                var logger = http.RequestServices.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("AdminOpsKeyFilter");
+                var validation = AdminOpsKeyMiddleware.ValidateOpsKey(http, cfg, logger);
                 if (validation is not null)
                     return validation;
 
@@ -123,11 +142,42 @@ namespace Tycoon.Backend.Api.Security
                     return await next(context);
                 }
 
+                var logger = http.RequestServices.GetRequiredService<ILoggerFactory>()
+                    .CreateLogger("AdminRoleClaims");
+
+                var user = http.User;
+                var isAuthenticated = user?.Identity?.IsAuthenticated == true;
+                var roles = user?.FindAll(System.Security.Claims.ClaimTypes.Role)
+                    .Concat(user.FindAll("role"))
+                    .Select(c => c.Value)
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .ToList() ?? [];
+                var hasAdminRole = roles.Contains("admin", StringComparer.OrdinalIgnoreCase);
+                var audClaims = user?.FindAll("aud").Select(c => c.Value).ToList() ?? [];
+                var hasAdminAud = audClaims.Contains("admin-app", StringComparer.Ordinal);
+                var scopeClaim = user?.FindFirst("scope")?.Value;
+                var hasUsersReadScope = scopeClaim?.Split(' ', StringSplitOptions.RemoveEmptyEntries)
+                    .Contains("users:read", StringComparer.OrdinalIgnoreCase) == true;
+
+                logger.LogDebug(
+                    "AdminRoleClaims check for {Method} {Path}: Authenticated={IsAuthenticated}, Roles=[{Roles}], HasAdminRole={HasAdminRole}, Aud=[{Aud}], HasAdminAppAud={HasAdminAud}, Scope={Scope}, HasUsersReadScope={HasUsersReadScope}",
+                    http.Request.Method, http.Request.Path, isAuthenticated, string.Join(",", roles), hasAdminRole,
+                    string.Join(",", audClaims), hasAdminAud, scopeClaim ?? "(none)", hasUsersReadScope);
+
                 var authz = http.RequestServices.GetRequiredService<IAuthorizationService>();
                 var authzResult = await authz.AuthorizeAsync(http.User, null, AdminPolicies.AdminOpsPolicy);
                 if (!authzResult.Succeeded)
                 {
-                    return http.User?.Identity?.IsAuthenticated == true
+                    var reason = !isAuthenticated ? "user is not authenticated"
+                        : !hasAdminRole ? $"JWT missing role=admin (found roles: [{string.Join(",", roles)}])"
+                        : !hasAdminAud ? $"JWT missing aud=admin-app (found aud: [{string.Join(",", audClaims)}])"
+                        : !hasUsersReadScope ? $"JWT missing scope users:read (found scope: {scopeClaim ?? "(none)"})"
+                        : "unknown policy failure (check AuthorizationFailure.FailureReasons)";
+
+                    logger.LogWarning("AdminRoleClaims FAILED for {Method} {Path}: {Reason}",
+                        http.Request.Method, http.Request.Path, reason);
+
+                    return isAuthenticated
                         ? ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin policy requirements not satisfied.")
                         : ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
                 }
@@ -143,8 +193,13 @@ namespace Tycoon.Backend.Api.Security
 
                 if (allowedEmails.Length > 0 && (string.IsNullOrWhiteSpace(email) || !allowedEmails.Contains(email, StringComparer.OrdinalIgnoreCase)))
                 {
+                    logger.LogWarning("AdminRoleClaims email allowlist FAILED for {Method} {Path}: email={Email}, allowlistCount={Count}",
+                        http.Request.Method, http.Request.Path, email ?? "(no email claim)", allowedEmails.Length);
                     return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is not allowlisted.");
                 }
+
+                logger.LogDebug("AdminRoleClaims PASSED for {Method} {Path}, email={Email}",
+                    http.Request.Method, http.Request.Path, email ?? "(none)");
 
                 return await next(context);
             });

--- a/Tycoon.Backend.Api/Security/AdminPolicies.cs
+++ b/Tycoon.Backend.Api/Security/AdminPolicies.cs
@@ -8,6 +8,7 @@ namespace Tycoon.Backend.Api.Security
         public const string AdminOnly = "AdminOnly";
         public const string AdminOpsPolicy = "AdminOps";
         public const string AdminNotificationsWritePolicy = "AdminNotificationsWrite";
+        public const string SuperAdminPolicy = "SuperAdmin";
 
         public static void AddAdminPolicies(this AuthorizationOptions options)
         {
@@ -31,6 +32,14 @@ namespace Tycoon.Backend.Api.Security
                 p.RequireRole("admin");
                 p.RequireClaim("aud", "admin-app");
                 p.RequireAssertion(ctx => HasScope(ctx.User, "notifications:write"));
+            });
+
+            options.AddPolicy(SuperAdminPolicy, p =>
+            {
+                p.RequireAuthenticatedUser();
+                p.RequireRole("admin");
+                p.RequireClaim("aud", "admin-app");
+                p.RequireAssertion(ctx => HasScope(ctx.User, "acl:write"));
             });
         }
 

--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -67,6 +67,7 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<TerritoryTile> TerritoryTiles { get; }
         DbSet<TerritoryDuel> TerritoryDuels { get; }
         DbSet<PlayerEventStats> PlayerEventStats { get; }
+        DbSet<AdminEmailAcl> AdminEmailAcls { get; }
 
         Task<int> SaveChangesAsync(CancellationToken ct = default);
         EntityEntry Entry(object entity);

--- a/Tycoon.Backend.Application/Auth/AuthService.cs
+++ b/Tycoon.Backend.Application/Auth/AuthService.cs
@@ -93,7 +93,17 @@ namespace Tycoon.Backend.Application.Auth
 
             authenticatedUser.RecordLogin();
 
-            var jwtToken = CreateJwtToken(authenticatedUser, clientType);
+            // Look up ACL role for admin logins to grant elevated scopes
+            AdminRole? aclRole = null;
+            if (clientType.Equals("admin", StringComparison.OrdinalIgnoreCase))
+            {
+                var normalizedEmail = authenticatedUser.Email.ToLowerInvariant();
+                var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
+                    .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
+                aclRole = aclEntry?.Role;
+            }
+
+            var jwtToken = CreateJwtToken(authenticatedUser, clientType, aclRole);
             var deviceRefreshToken = await CreateRefreshTokenForDevice(
                 authenticatedUser.Id, deviceId, clientType);
 
@@ -123,7 +133,16 @@ namespace Tycoon.Backend.Application.Auth
 
             storedToken.Revoke();
 
-            var newJwtToken = CreateJwtToken(tokenOwner, expectedClientType);
+            AdminRole? aclRole = null;
+            if (expectedClientType.Equals("admin", StringComparison.OrdinalIgnoreCase))
+            {
+                var normalizedEmail = tokenOwner.Email.ToLowerInvariant();
+                var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
+                    .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
+                aclRole = aclEntry?.Role;
+            }
+
+            var newJwtToken = CreateJwtToken(tokenOwner, expectedClientType, aclRole);
             var newDeviceToken = await CreateRefreshTokenForDevice(
                 tokenOwner.Id, storedToken.DeviceId, expectedClientType);
 
@@ -134,13 +153,17 @@ namespace Tycoon.Backend.Application.Auth
 
         // ── Token helpers ─────────────────────────────────────────────────────
 
-        private string CreateJwtToken(User user, string clientType)
+        private string CreateJwtToken(User user, string clientType, AdminRole? aclRole = null)
         {
             var isAdmin = clientType.Equals("admin", StringComparison.OrdinalIgnoreCase);
 
             var scopes = isAdmin
                 ? "users:read users:write questions:read questions:write events:read events:write notifications:write config:write"
                 : "profile:read profile:write gameplay:read gameplay:write";
+
+            // Super admins get ACL management scope
+            if (isAdmin && aclRole == AdminRole.SuperAdmin)
+                scopes += " acl:write";
 
             var role = isAdmin ? "admin" : "user";
             var audience = isAdmin ? "admin-app" : "mobile-app";

--- a/Tycoon.Backend.Domain/Entities/AdminEmailAcl.cs
+++ b/Tycoon.Backend.Domain/Entities/AdminEmailAcl.cs
@@ -1,0 +1,56 @@
+using Tycoon.Backend.Domain.Primitives;
+
+namespace Tycoon.Backend.Domain.Entities;
+
+/// <summary>
+/// Access-control entry for an admin email address.
+/// Supports allow/block lists with role assignment.
+/// Blocklist entries take precedence over allowlist entries.
+/// </summary>
+public sealed class AdminEmailAcl : Entity
+{
+    public string Email { get; private set; } = string.Empty;
+    public string NormalizedEmail { get; private set; } = string.Empty;
+    public AdminAclListType ListType { get; private set; }
+    public AdminRole Role { get; private set; }
+    public string? Notes { get; private set; }
+    public string AddedBy { get; private set; } = string.Empty;
+    public DateTimeOffset CreatedAtUtc { get; private set; }
+    public DateTimeOffset UpdatedAtUtc { get; private set; }
+
+    private AdminEmailAcl() { }
+
+    public AdminEmailAcl(string email, AdminAclListType listType, AdminRole role, string addedBy, string? notes = null)
+    {
+        Id = Guid.NewGuid();
+        Email = email.Trim();
+        NormalizedEmail = email.Trim().ToLowerInvariant();
+        ListType = listType;
+        Role = role;
+        AddedBy = addedBy;
+        Notes = notes;
+        CreatedAtUtc = DateTimeOffset.UtcNow;
+        UpdatedAtUtc = DateTimeOffset.UtcNow;
+    }
+
+    public void Update(AdminAclListType listType, AdminRole role, string? notes)
+    {
+        ListType = listType;
+        Role = role;
+        Notes = notes;
+        UpdatedAtUtc = DateTimeOffset.UtcNow;
+    }
+}
+
+public enum AdminAclListType
+{
+    Allow = 0,
+    Block = 1
+}
+
+public enum AdminRole
+{
+    Viewer = 0,
+    Admin = 1,
+    SuperAdmin = 2
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -84,6 +84,7 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<TerritoryTile> TerritoryTiles => Set<TerritoryTile>();
         public DbSet<TerritoryDuel> TerritoryDuels => Set<TerritoryDuel>();
         public DbSet<PlayerEventStats> PlayerEventStats => Set<PlayerEventStats>();
+        public DbSet<AdminEmailAcl> AdminEmailAcls => Set<AdminEmailAcl>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/AdminEmailAclConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/AdminEmailAclConfiguration.cs
@@ -1,0 +1,51 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Entities;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class AdminEmailAclConfiguration : IEntityTypeConfiguration<AdminEmailAcl>
+{
+    public void Configure(EntityTypeBuilder<AdminEmailAcl> builder)
+    {
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Email)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(e => e.NormalizedEmail)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(e => e.ListType)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(16);
+
+        builder.Property(e => e.Role)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(32);
+
+        builder.Property(e => e.Notes)
+            .HasMaxLength(500);
+
+        builder.Property(e => e.AddedBy)
+            .IsRequired()
+            .HasMaxLength(256);
+
+        builder.Property(e => e.CreatedAtUtc)
+            .IsRequired();
+
+        builder.Property(e => e.UpdatedAtUtc)
+            .IsRequired();
+
+        // One entry per email — an email cannot be on both lists simultaneously
+        builder.HasIndex(e => e.NormalizedEmail)
+            .IsUnique();
+
+        // Fast filtering by list type
+        builder.HasIndex(e => e.ListType);
+    }
+}

--- a/Tycoon.Shared.Contracts/Dtos/AdminEmailAclDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/AdminEmailAclDtos.cs
@@ -1,0 +1,29 @@
+namespace Tycoon.Shared.Contracts.Dtos;
+
+public record AdminEmailAclEntryDto(
+    Guid Id,
+    string Email,
+    string ListType,
+    string Role,
+    string? Notes,
+    string AddedBy,
+    DateTimeOffset CreatedAtUtc,
+    DateTimeOffset UpdatedAtUtc);
+
+public record CreateAdminEmailAclRequest(
+    string Email,
+    string ListType,
+    string Role,
+    string? Notes);
+
+public record UpdateAdminEmailAclRequest(
+    string ListType,
+    string Role,
+    string? Notes);
+
+public record AdminEmailAclListResponse(
+    IReadOnlyList<AdminEmailAclEntryDto> Items,
+    int Page,
+    int PageSize,
+    int TotalItems,
+    int TotalPages);


### PR DESCRIPTION
## Summary
Replaces the static configuration-based admin email allowlist with a dynamic, database-backed access control list (ACL) system. Admins can now manage email allowlists and blocklists through API endpoints, with role-based access control and comprehensive audit logging.

## Key Changes

- **New AdminEmailAcl Entity & Configuration**
  - Added `AdminEmailAcl` domain entity with support for Allow/Block list types and role assignment (Viewer, Admin, SuperAdmin)
  - Configured with unique constraint on normalized email and index on list type for efficient queries
  - Includes audit fields (AddedBy, CreatedAtUtc, UpdatedAtUtc)

- **Admin Email ACL API Endpoints** (`AdminEmailAclEndpoints.cs`)
  - GET `/admin/email-acl` - List ACL entries with pagination and filtering by list type (requires AdminOpsPolicy)
  - GET `/admin/email-acl/{id}` - Retrieve single ACL entry (requires AdminOpsPolicy)
  - POST `/admin/email-acl` - Create new ACL entry with validation (requires SuperAdminPolicy)
  - PATCH `/admin/email-acl/{id}` - Update existing ACL entry (requires SuperAdminPolicy)
  - DELETE `/admin/email-acl/{id}` - Remove ACL entry (requires SuperAdminPolicy)
  - All write operations logged to security audit trail

- **Enhanced Authorization & Authentication**
  - Added `SuperAdminPolicy` requiring `acl:write` scope for ACL management
  - Updated `AdminRoleClaims` filter to check database ACL entries instead of static config
  - Blocklist entries take precedence over allowlist entries
  - If allowlist entries exist, only allowlisted emails are permitted; otherwise open access
  - Added comprehensive debug/warning logging for authorization decisions

- **AuthService Integration**
  - Modified `LoginInternalAsync` and `RefreshInternalAsync` to look up ACL role for admin logins
  - SuperAdmin role grants `acl:write` scope in JWT token
  - ACL role lookup only performed for admin client type

- **AdminOpsKeyMiddleware Improvements**
  - Added logging for key validation failures (missing header, invalid key)
  - Logs last 4 characters of provided key for debugging without exposing full key
  - Updated filter to use logger factory for consistent logging

- **Migration from Static Config**
  - `AdminAuthEndpoints.IsAdminEmail()` now queries database ACL instead of configuration
  - Maintains backward compatibility: no allowlist entries = open access

## Notable Implementation Details

- Email normalization (trim + lowercase) ensures consistent lookups
- Unique constraint on `NormalizedEmail` prevents duplicate entries
- Blocklist precedence prevents accidental lockouts when both list types exist
- All ACL modifications include actor tracking and security audit logging
- Comprehensive validation of enum values (ListType, Role) with user-friendly error messages

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w