### PR TITLE
Fix CS0136: remove duplicate normalizedEmail declaration in LoginInte…

### DIFF
--- a/Tycoon.Backend.Application/Auth/AuthService.cs
+++ b/Tycoon.Backend.Application/Auth/AuthService.cs
@@ -97,7 +97,6 @@ namespace Tycoon.Backend.Application.Auth
             AdminRole? aclRole = null;
             if (clientType.Equals("admin", StringComparison.OrdinalIgnoreCase))
             {
-                var normalizedEmail = authenticatedUser.Email.ToLowerInvariant();
                 var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
                     .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
                 aclRole = aclEntry?.Role;


### PR DESCRIPTION
…rnalAsync

The ACL role lookup block redeclared normalizedEmail inside a nested if, shadowing the outer-scope variable. Removed the inner declaration since the outer one (from line 80) already holds the same normalized value.

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w