### PR TITLE
Add EF Core migration to create admin_email_acls table

### DIFF
--- a/Tycoon.Backend.Migrations/Migrations/20260322000000_AddAdminEmailAcl.Designer.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260322000000_AddAdminEmailAcl.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tycoon.Backend.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Tycoon.Backend.Infrastructure.Persistence;
 namespace Tycoon.Backend.Migrations.Migrations
 {
     [DbContext(typeof(AppDb))]
-    partial class AppDbModelSnapshot : ModelSnapshot
+    [Migration("20260322000000_AddAdminEmailAcl")]
+    partial class AddAdminEmailAcl
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Tycoon.Backend.Migrations/Migrations/20260322000000_AddAdminEmailAcl.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260322000000_AddAdminEmailAcl.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tycoon.Backend.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAdminEmailAcl : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "admin_email_acls",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    normalized_email = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    list_type = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false),
+                    role = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    notes = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    added_by = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    created_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at_utc = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_admin_email_acls", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_admin_email_acls_list_type",
+                table: "admin_email_acls",
+                column: "list_type");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_admin_email_acls_normalized_email",
+                table: "admin_email_acls",
+                column: "normalized_email",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "admin_email_acls");
+        }
+    }
+}


### PR DESCRIPTION
Creates the admin_email_acls table with columns for email, normalized_email, list_type, role, notes, added_by, and timestamps. Includes a unique index on normalized_email and an index on list_type for fast lookups.

This was missing from the previous commit that added the AdminEmailAcl entity and caused 500 errors on login (table did not exist in the database).

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w