### PR TITLE
Fix .dockerignore excluding source files matching *token*, *secret*, …

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -64,10 +64,6 @@
 !.env.example
 secrets/
 **/secrets/
-**/*secret*
-**/*password*
-**/*apikey*
-**/*token*
 
 # =========================
 


### PR DESCRIPTION
…etc.

The overly broad glob patterns **/*token*, **/*secret*, **/*password*, and **/*apikey* were excluding legitimate source files like TokenStore.cs and BearerTokenStore.cs from the Docker build context. This caused the OperatorDashboard build to fail with misleading CS1513/CS1026 errors because the DI registrations in Program.cs referenced missing types.

Removed the broad filename patterns and kept directory-level exclusions (secrets/) which are sufficient for preventing actual secrets from being included in Docker images.

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w