### PR TITLE
Fix Dashboard Program.cs syntax and unseal TycoonApiFactory for test …

### DIFF
--- a/Tycoon.Backend.Api.Tests/TestHost/TycoonApiFactory.cs
+++ b/Tycoon.Backend.Api.Tests/TestHost/TycoonApiFactory.cs
@@ -3,7 +3,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace Tycoon.Backend.Api.Tests.TestHost
 {
-    public sealed class TycoonApiFactory : WebApplicationFactory<Program>
+    public class TycoonApiFactory : WebApplicationFactory<Program>
     {
         public const string TestAdminKey = "test-admin-ops-key";
 

--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -41,6 +41,10 @@ var apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? "http://tycoon-api";
 builder.Services.AddHttpClient("tycoon-api", client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
+    var opsKey = builder.Configuration["AdminOps:Key"] ?? string.Empty;
+    if (!string.IsNullOrEmpty(opsKey))
+        client.DefaultRequestHeaders.TryAddWithoutValidation("X-Admin-Ops-Key", opsKey);
+});
 
 // AdminApiClient is scoped — one shared instance per Blazor Server circuit.
 // This is the critical fix: AddHttpClient<T> registers T as transient, meaning


### PR DESCRIPTION
…inheritance

- Restore missing AddHttpClient closing block and ops key setup in OperatorDashboard Program.cs (the lambda was left unclosed)
- Remove sealed from TycoonApiFactory so AdminEconomyFallbackFactory can inherit from it (CS0509)

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w