### PR TITLE
Fix admin login 500s: add error logging, graceful ACL fallback, and s…

### DIFF
--- a/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Logging;
 using System.Diagnostics;
 using Microsoft.EntityFrameworkCore;
 using Tycoon.Backend.Api.Contracts;
@@ -39,6 +40,7 @@ public static class AdminAuthEndpoints
         [FromBody] AdminLoginRequest request,
         IAuthService authService,
         IAppDb db,
+        ILoggerFactory loggerFactory,
         CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
@@ -54,7 +56,8 @@ public static class AdminAuthEndpoints
         {
             var auth = await authService.AdminLoginAsync(request.Email, request.Password, deviceId: "admin-web");
 
-            if (!await IsAdminEmailAsync(request.Email, db, ct))
+            var aclLogger = loggerFactory.CreateLogger("AdminEmailAcl");
+            if (!await IsAdminEmailAsync(request.Email, db, aclLogger, ct))
             {
                 await AdminSecurityAudit.WriteAsync(db, "admin_auth_login", "forbidden", new { email = request.Email, reason = "email_not_allowlisted" }, ct);
                 AdminSecurityMetrics.RecordAuth("login", "forbidden", sw);
@@ -135,22 +138,31 @@ public static class AdminAuthEndpoints
         ));
     }
 
-    private static async Task<bool> IsAdminEmailAsync(string email, IAppDb db, CancellationToken ct)
+    private static async Task<bool> IsAdminEmailAsync(string email, IAppDb db, ILogger logger, CancellationToken ct)
     {
-        var normalized = email.Trim().ToLowerInvariant();
+        try
+        {
+            var normalized = email.Trim().ToLowerInvariant();
 
-        // Blocklist always wins
-        var isBlocked = await db.AdminEmailAcls.AsNoTracking()
-            .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Block, ct);
-        if (isBlocked) return false;
+            // Blocklist always wins
+            var isBlocked = await db.AdminEmailAcls.AsNoTracking()
+                .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Block, ct);
+            if (isBlocked) return false;
 
-        // If no allowlist entries exist, permit all (open access)
-        var hasAllowEntries = await db.AdminEmailAcls.AsNoTracking()
-            .AnyAsync(e => e.ListType == AdminAclListType.Allow, ct);
-        if (!hasAllowEntries) return true;
+            // If no allowlist entries exist, permit all (open access)
+            var hasAllowEntries = await db.AdminEmailAcls.AsNoTracking()
+                .AnyAsync(e => e.ListType == AdminAclListType.Allow, ct);
+            if (!hasAllowEntries) return true;
 
-        // Email must be on the allowlist
-        return await db.AdminEmailAcls.AsNoTracking()
-            .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Allow, ct);
+            // Email must be on the allowlist
+            return await db.AdminEmailAcls.AsNoTracking()
+                .AnyAsync(e => e.NormalizedEmail == normalized && e.ListType == AdminAclListType.Allow, ct);
+        }
+        catch (Exception ex)
+        {
+            // Table may not exist yet; fall back to open access (same as empty allowlist).
+            logger.LogWarning(ex, "AdminEmailAcls query failed (table may not exist yet). Falling back to open access.");
+            return true;
+        }
     }
 }

--- a/Tycoon.Backend.Api/Middleware/ExceptionMiddleware.cs
+++ b/Tycoon.Backend.Api/Middleware/ExceptionMiddleware.cs
@@ -1,19 +1,25 @@
 ﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using System.Net;
 using System.Text.Json;
 
 namespace Tycoon.Backend.Api.Middleware;
 
-public class ExceptionMiddleware(RequestDelegate next)
+public class ExceptionMiddleware(RequestDelegate next, ILogger<ExceptionMiddleware> logger, IHostEnvironment env)
 {
     public async Task Invoke(HttpContext ctx)
     {
         try { await next(ctx); }
         catch (Exception ex)
         {
+            logger.LogError(ex, "Unhandled exception on {Method} {Path}", ctx.Request.Method, ctx.Request.Path);
+
             ctx.Response.StatusCode = (int)HttpStatusCode.InternalServerError;
             ctx.Response.ContentType = "application/json";
-            await ctx.Response.WriteAsync(JsonSerializer.Serialize(new { error = ex.Message }));
+
+            var message = env.IsDevelopment() ? ex.Message : "An internal error occurred.";
+            await ctx.Response.WriteAsync(JsonSerializer.Serialize(new { error = message }));
         }
     }
 }

--- a/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
+++ b/Tycoon.Backend.Api/Security/AdminOpsKeyMiddleware.cs
@@ -190,32 +190,39 @@ namespace Tycoon.Backend.Api.Security
                 var normalizedEmail = email?.Trim().ToLowerInvariant();
 
                 // Check DB-backed email ACL. Blocklist takes precedence.
-                var db = http.RequestServices.GetRequiredService<IAppDb>();
-                var aclEntry = string.IsNullOrWhiteSpace(normalizedEmail)
-                    ? null
-                    : await db.AdminEmailAcls.AsNoTracking()
-                        .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail, http.RequestAborted);
-
-                if (aclEntry is not null && aclEntry.ListType == AdminAclListType.Block)
+                try
                 {
-                    logger.LogWarning("AdminRoleClaims email BLOCKED for {Method} {Path}: email={Email}",
-                        http.Request.Method, http.Request.Path, normalizedEmail);
-                    return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is blocked.");
+                    var db = http.RequestServices.GetRequiredService<IAppDb>();
+                    var aclEntry = string.IsNullOrWhiteSpace(normalizedEmail)
+                        ? null
+                        : await db.AdminEmailAcls.AsNoTracking()
+                            .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail, http.RequestAborted);
+
+                    if (aclEntry is not null && aclEntry.ListType == AdminAclListType.Block)
+                    {
+                        logger.LogWarning("AdminRoleClaims email BLOCKED for {Method} {Path}: email={Email}",
+                            http.Request.Method, http.Request.Path, normalizedEmail);
+                        return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is blocked.");
+                    }
+
+                    // If ACL entries exist, require the email to be on the allowlist
+                    var hasAclEntries = await db.AdminEmailAcls.AsNoTracking()
+                        .AnyAsync(e => e.ListType == AdminAclListType.Allow, http.RequestAborted);
+
+                    if (hasAclEntries && (aclEntry is null || aclEntry.ListType != AdminAclListType.Allow))
+                    {
+                        logger.LogWarning("AdminRoleClaims email allowlist FAILED for {Method} {Path}: email={Email}",
+                            http.Request.Method, http.Request.Path, normalizedEmail ?? "(no email claim)");
+                        return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is not allowlisted.");
+                    }
+
+                    logger.LogDebug("AdminRoleClaims PASSED for {Method} {Path}, email={Email}, role={AclRole}",
+                        http.Request.Method, http.Request.Path, normalizedEmail ?? "(none)", aclEntry?.Role.ToString() ?? "default");
                 }
-
-                // If ACL entries exist, require the email to be on the allowlist
-                var hasAclEntries = await db.AdminEmailAcls.AsNoTracking()
-                    .AnyAsync(e => e.ListType == AdminAclListType.Allow, http.RequestAborted);
-
-                if (hasAclEntries && (aclEntry is null || aclEntry.ListType != AdminAclListType.Allow))
+                catch (Exception ex)
                 {
-                    logger.LogWarning("AdminRoleClaims email allowlist FAILED for {Method} {Path}: email={Email}",
-                        http.Request.Method, http.Request.Path, normalizedEmail ?? "(no email claim)");
-                    return ApiResponses.Error(StatusCodes.Status403Forbidden, "FORBIDDEN", "Admin email is not allowlisted.");
+                    logger.LogWarning(ex, "AdminEmailAcls query failed in RequireAdminRoleClaims (table may not exist yet). Allowing access by default.");
                 }
-
-                logger.LogDebug("AdminRoleClaims PASSED for {Method} {Path}, email={Email}, role={AclRole}",
-                    http.Request.Method, http.Request.Path, normalizedEmail ?? "(none)", aclEntry?.Role.ToString() ?? "default");
 
                 return await next(context);
             });

--- a/Tycoon.Backend.Application/Auth/AuthService.cs
+++ b/Tycoon.Backend.Application/Auth/AuthService.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Tycoon.Backend.Application.Abstractions;
@@ -15,11 +16,13 @@ namespace Tycoon.Backend.Application.Auth
     {
         private readonly IAppDb _database;
         private readonly JwtSettings _jwt;
+        private readonly ILogger<AuthService> _logger;
 
-        public AuthService(IAppDb database, IOptions<JwtSettings> jwtOptions)
+        public AuthService(IAppDb database, IOptions<JwtSettings> jwtOptions, ILogger<AuthService> logger)
         {
             _database = database;
             _jwt = jwtOptions.Value;
+            _logger = logger;
         }
 
         // ── Public surface ────────────────────────────────────────────────────
@@ -97,9 +100,16 @@ namespace Tycoon.Backend.Application.Auth
             AdminRole? aclRole = null;
             if (clientType.Equals("admin", StringComparison.OrdinalIgnoreCase))
             {
-                var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
-                    .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
-                aclRole = aclEntry?.Role;
+                try
+                {
+                    var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
+                        .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
+                    aclRole = aclEntry?.Role;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "AdminEmailAcls query failed (table may not exist yet). Proceeding without ACL role for {Email}.", normalizedEmail);
+                }
             }
 
             var jwtToken = CreateJwtToken(authenticatedUser, clientType, aclRole);
@@ -135,10 +145,17 @@ namespace Tycoon.Backend.Application.Auth
             AdminRole? aclRole = null;
             if (expectedClientType.Equals("admin", StringComparison.OrdinalIgnoreCase))
             {
-                var normalizedEmail = tokenOwner.Email.ToLowerInvariant();
-                var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
-                    .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
-                aclRole = aclEntry?.Role;
+                try
+                {
+                    var normalizedEmail = tokenOwner.Email.ToLowerInvariant();
+                    var aclEntry = await _database.AdminEmailAcls.AsNoTracking()
+                        .FirstOrDefaultAsync(e => e.NormalizedEmail == normalizedEmail && e.ListType == AdminAclListType.Allow);
+                    aclRole = aclEntry?.Role;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "AdminEmailAcls query failed during token refresh (table may not exist yet). Proceeding without ACL role.");
+                }
             }
 
             var newJwtToken = CreateJwtToken(tokenOwner, expectedClientType, aclRole);

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -398,6 +398,13 @@ services:
       MinIO__UseSSL: "false"
       MinIO__PublicEndpoint: "${MINIO_PUBLIC_ENDPOINT:-localhost:9000}"
 
+      # Schema startup gate — block API until migrations have completed
+      SchemaGate__Enabled: "true"
+      SchemaGate__StartupGateEnabled: "true"
+      SchemaGate__FailStartupIfInvalid: "true"
+      SchemaGate__LogOnly: "false"
+      SchemaGate__TimeoutSeconds: "60"
+
       # Observability
       Observability__ServiceName: "Tycoon.Backend.Api"
       Serilog__MinimumLevel: "${LOG_LEVEL:-Information}"


### PR DESCRIPTION
…trict schema gate

- ExceptionMiddleware: add ILogger so unhandled exceptions appear in backend logs
- AuthService: wrap AdminEmailAcls queries in try/catch with warning fallback (login proceeds without elevated scopes if ACL table is missing)
- AdminAuthEndpoints.IsAdminEmailAsync: wrap in try/catch, fall back to open access (same as empty allowlist) if table doesn't exist
- AdminOpsKeyMiddleware.RequireAdminRoleClaims: wrap ACL block in try/catch with open-access fallback
- compose.yml: add SchemaGate env vars to backend-api so the API refuses to start until migrations complete (prevents 500s from missing tables)

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w