### PR TITLE
Fix SchemaStartupGate: quote identifiers in to_regclass() for case-se…

### DIFF
--- a/Tycoon.Backend.Infrastructure/Persistence/Startup/SchemaStartupGate.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Startup/SchemaStartupGate.cs
@@ -110,8 +110,10 @@ public sealed class SchemaStartupGate
 
     private static async Task<bool> ExistsAsync(AppDb db, string schema, string table, CancellationToken ct)
     {
-        // Postgres: to_regclass('schema.table') returns NULL if missing.
-        var qualified = $"{schema}.{table}";
+        // Postgres: to_regclass() parses its argument as an SQL identifier.
+        // Unquoted names are lowercased, so we must double-quote each part to
+        // preserve the original casing (e.g. "__EFMigrationsHistory").
+        var qualified = $"\"{schema}\".\"{table}\"";
 
         var connection = db.Database.GetDbConnection();
         var shouldClose = connection.State != ConnectionState.Open;


### PR DESCRIPTION
…nsitive table names

to_regclass() lowercases unquoted identifiers, so passing public.__EFMigrationsHistory resolved to public.__efmigrationshistory and always returned NULL — even though the migration table existed. Wrapping schema and table in double quotes preserves mixed case.

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w