### PR TITLE
Fix Dashboard DI crash: AdminApiClient now takes IHttpClientFactory d…

### DIFF
--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -51,17 +51,10 @@ builder.Services.AddHttpClient("tycoon-api", client =>
 });
 
 // AdminApiClient is scoped — one shared instance per Blazor Server circuit.
-// This is the critical fix: AddHttpClient<T> registers T as transient, meaning
-// Dashboard.razor and AdminAuthService receive different instances. SetToken() on
-// AdminAuthService's instance never affected Dashboard.razor's instance → 401s.
-// With a scoped registration, both resolve the same object from the circuit scope,
-// so SetToken() and all subsequent Api.* calls use the same HttpClient headers.
-builder.Services.AddScoped<AdminApiClient>(sp =>
-{
-    var factory = sp.GetRequiredService<IHttpClientFactory>();
-    var config  = sp.GetRequiredService<IConfiguration>();
-    return new AdminApiClient(factory.CreateClient("tycoon-api"), config);
-});
+// It takes IHttpClientFactory in its constructor and creates the named "tycoon-api" client.
+// Scoped ensures Dashboard.razor and AdminAuthService share the same instance per circuit,
+// so SetToken() and all subsequent API calls use the same HttpClient headers.
+builder.Services.AddScoped<AdminApiClient>();
 
 var app = builder.Build();
 

--- a/Tycoon.OperatorDashboard/Services/AdminApiClient.cs
+++ b/Tycoon.OperatorDashboard/Services/AdminApiClient.cs
@@ -10,9 +10,18 @@ namespace Tycoon.OperatorDashboard.Services;
 /// <summary>
 /// Typed HttpClient wrapping all admin REST endpoints on tycoon-api.
 /// Attach the caller's JWT before each call via SetToken().
+/// Accepts IHttpClientFactory so DI can construct this directly (scoped lifetime).
 /// </summary>
-public sealed class AdminApiClient(HttpClient http, IConfiguration config)
+public sealed class AdminApiClient
 {
+    private readonly HttpClient http;
+    private readonly IConfiguration config;
+
+    public AdminApiClient(IHttpClientFactory httpFactory, IConfiguration config)
+    {
+        this.http = httpFactory.CreateClient("tycoon-api");
+        this.config = config;
+    }
     private static readonly JsonSerializerOptions Json = new()
     {
         PropertyNameCaseInsensitive = true,


### PR DESCRIPTION
…irectly

AdminApiClient's primary constructor took (HttpClient, IConfiguration) and was registered via AddScoped<T>(factory lambda). .NET 9's ValidateOnBuild in Development mode couldn't validate this factory-based registration when checking AdminAuthService's constructor dependencies, causing a startup crash.

Changed AdminApiClient to accept IHttpClientFactory in its constructor and create the named "tycoon-api" HttpClient internally. This allows standard AddScoped<AdminApiClient>() registration that DI validation can resolve.

https://claude.ai/code/session_01FjoQCqDMXvTQxhRa7pAn7w