### PR TITLE
Add migration reset automation and simplify migration project includes

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,25 @@ make -f docker/MakeFile migrate
 ### Creating New Migrations
 
 ```bash
-cd Tycoon.Backend.Infrastructure
-dotnet ef migrations add YourMigrationName --startup-project ../Tycoon.Backend.Api
+dotnet ef migrations add YourMigrationName \
+  --project Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj \
+  --startup-project Tycoon.MigrationService/Tycoon.MigrationService.csproj \
+  --context AppDb \
+  --output-dir Migrations
 ```
+
+### Resetting Migrations (Start Over)
+
+To wipe `Tycoon.Backend.Migrations/Migrations` and recreate a fresh baseline migration:
+
+```bash
+./scripts/reset-migrations.sh --force --name InitialCreate
+```
+
+Useful options:
+
+- `--skip-add` : clear migration files only (no new migration generated)
+- `--name <Name>` : set the baseline migration name
 
 ### Migration Modes
 
@@ -603,4 +619,3 @@ Built with:
 ---
 
 **Happy coding! 🚀**
-

--- a/Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj
+++ b/Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj
@@ -9,19 +9,7 @@
 
   <ItemGroup>
     <Compile Include="MigrationAssemblyMarker.cs" />
-    <Compile Include="Migrations\AppDbModelSnapshot.cs" />
-    <Compile Include="Migrations\20260303024251_InitialCreate.cs" />
-    <Compile Include="Migrations\20260303024251_InitialCreate.Designer.cs" />
-    <Compile Include="Migrations\20260315000000_AddPlayerEventStats.cs" />
-    <Compile Include="Migrations\20260315000000_AddPlayerEventStats.Designer.cs" />
-    <Compile Include="Migrations\20260319000000_AddGameEventTables.cs" />
-    <Compile Include="Migrations\20260319000000_AddGameEventTables.Designer.cs" />
-    <Compile Include="Migrations\20260321090000_AddGameBalancePolicyPersistence.cs" />
-    <Compile Include="Migrations\20260321090000_AddGameBalancePolicyPersistence.Designer.cs" />
-    <Compile Include="Migrations\20260322000000_AddAdminEmailAcl.cs" />
-    <Compile Include="Migrations\20260322000000_AddAdminEmailAcl.Designer.cs" />
-    <Compile Include="Migrations\20260323000000_NormalizeSnakeCaseNaming.cs" />
-    <Compile Include="Migrations\20260323000000_NormalizeSnakeCaseNaming.Designer.cs" />
+    <Compile Include="Migrations\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/scripts/reset-migrations.sh
+++ b/scripts/reset-migrations.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+MIGRATIONS_DIR="Tycoon.Backend.Migrations/Migrations"
+PROJECT="Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj"
+STARTUP_PROJECT="Tycoon.MigrationService/Tycoon.MigrationService.csproj"
+CONTEXT="AppDb"
+MIGRATION_NAME="InitialCreate"
+SKIP_ADD=false
+FORCE=false
+
+usage() {
+  cat <<USAGE
+Usage: ./scripts/reset-migrations.sh [options]
+
+Resets Tycoon.Backend.Migrations/Migrations and optionally recreates a fresh baseline migration.
+
+Options:
+  --name <MigrationName>  Name for the new baseline migration (default: InitialCreate)
+  --skip-add              Only clear migration files; do not run 'dotnet ef migrations add'
+  --force                 Skip confirmation prompt
+  -h, --help              Show this help text
+USAGE
+}
+
+log() {
+  echo "[reset-migrations] $*"
+}
+
+confirm_or_exit() {
+  if $FORCE; then
+    return 0
+  fi
+
+  echo "This will permanently delete all files under '$MIGRATIONS_DIR'."
+  read -r -p "Continue? [y/N] " reply
+  case "$reply" in
+    [yY]|[yY][eE][sS]) ;;
+    *) log "Canceled."; exit 0 ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      [[ $# -ge 2 ]] || { echo "Missing value for --name" >&2; exit 1; }
+      MIGRATION_NAME="$2"
+      shift 2
+      ;;
+    --skip-add)
+      SKIP_ADD=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "Migrations directory not found: $MIGRATIONS_DIR" >&2
+  exit 1
+fi
+
+confirm_or_exit
+
+log "Clearing migration files..."
+find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.cs' -delete
+
+if $SKIP_ADD; then
+  log "Done. Migration files were cleared and no new migration was created (--skip-add)."
+  exit 0
+fi
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet CLI is required but not found in PATH." >&2
+  exit 1
+fi
+
+log "Creating new baseline migration '$MIGRATION_NAME'..."
+dotnet ef migrations add "$MIGRATION_NAME" \
+  --project "$PROJECT" \
+  --startup-project "$STARTUP_PROJECT" \
+  --context "$CONTEXT" \
+  --output-dir Migrations
+
+log "Done. New baseline migration created in '$MIGRATIONS_DIR'."


### PR DESCRIPTION
### Motivation

- Provide a safe, repeatable way to clear and re-bootstrap the EF Core migrations directory so the project can start over cleanly. 
- Avoid the brittle workflow of manually adding every migration `.cs` file to the migrations project when regenerating migrations. 
- Document the correct EF Core command and the new reset workflow so contributors can perform the operation consistently.

### Description

- Add `scripts/reset-migrations.sh`, a CLI script that clears `Tycoon.Backend.Migrations/Migrations` and optionally runs `dotnet ef migrations add` to create a fresh baseline, with options `--force`, `--skip-add`, and `--name` to control behavior. 
- Change `Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj` to auto-include migration source files using `Migrations\**\*.cs` so new/regen'd migration files are picked up automatically. 
- Update `README.md` to show the correct EF command (`dotnet ef migrations add ... --project ... --startup-project ... --context AppDb --output-dir Migrations`) and add documentation for the reset workflow and `scripts/reset-migrations.sh` usage.

### Testing

- Verified the reset script help output with `./scripts/reset-migrations.sh --help`, which displayed the usage and options successfully. 
- Attempted to build the migrations project with `dotnet build Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj`, which could not be executed in this environment because the `dotnet` CLI is not installed (failure due to environment, not the changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a46ae280832d91708878c4f60d71)