### PR TITLE
Add reset-migrations script, update migration docs, and consolidate migration compile items

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,9 +344,26 @@ make -f docker/MakeFile migrate
 ### Creating New Migrations
 
 ```bash
-cd Tycoon.Backend.Infrastructure
-dotnet ef migrations add YourMigrationName --startup-project ../Tycoon.Backend.Api
+dotnet ef migrations add YourMigrationName \
+  --project Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj \
+  --startup-project Tycoon.Backend.Api/Tycoon.Backend.Api.csproj \
+  --context AppDb \
+  --output-dir Migrations
 ```
+
+### Resetting Migrations (Start Over)
+
+To wipe `Tycoon.Backend.Migrations/Migrations` and recreate a fresh baseline migration:
+
+```bash
+./scripts/reset-migrations.sh --force --name InitialCreate
+```
+
+Useful options:
+
+- `--skip-add` : clear migration files only (no new migration generated)
+- `--name <Name>` : set the baseline migration name
+- Runs `scripts/validate-ef-schema.sh` after regeneration to catch pending model changes early
 
 ### Migration Modes
 
@@ -603,4 +620,3 @@ Built with:
 ---
 
 **Happy coding! 🚀**
-

--- a/Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj
+++ b/Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj
@@ -9,19 +9,7 @@
 
   <ItemGroup>
     <Compile Include="MigrationAssemblyMarker.cs" />
-    <Compile Include="Migrations\AppDbModelSnapshot.cs" />
-    <Compile Include="Migrations\20260303024251_InitialCreate.cs" />
-    <Compile Include="Migrations\20260303024251_InitialCreate.Designer.cs" />
-    <Compile Include="Migrations\20260315000000_AddPlayerEventStats.cs" />
-    <Compile Include="Migrations\20260315000000_AddPlayerEventStats.Designer.cs" />
-    <Compile Include="Migrations\20260319000000_AddGameEventTables.cs" />
-    <Compile Include="Migrations\20260319000000_AddGameEventTables.Designer.cs" />
-    <Compile Include="Migrations\20260321090000_AddGameBalancePolicyPersistence.cs" />
-    <Compile Include="Migrations\20260321090000_AddGameBalancePolicyPersistence.Designer.cs" />
-    <Compile Include="Migrations\20260322000000_AddAdminEmailAcl.cs" />
-    <Compile Include="Migrations\20260322000000_AddAdminEmailAcl.Designer.cs" />
-    <Compile Include="Migrations\20260323000000_NormalizeSnakeCaseNaming.cs" />
-    <Compile Include="Migrations\20260323000000_NormalizeSnakeCaseNaming.Designer.cs" />
+    <Compile Include="Migrations\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/scripts/reset-migrations.sh
+++ b/scripts/reset-migrations.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+MIGRATIONS_DIR="Tycoon.Backend.Migrations/Migrations"
+PROJECT="Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj"
+STARTUP_PROJECT="Tycoon.Backend.Api/Tycoon.Backend.Api.csproj"
+CONTEXT="AppDb"
+MIGRATION_NAME="InitialCreate"
+SKIP_ADD=false
+FORCE=false
+
+usage() {
+  cat <<USAGE
+Usage: ./scripts/reset-migrations.sh [options]
+
+Resets Tycoon.Backend.Migrations/Migrations and optionally recreates a fresh baseline migration.
+
+Options:
+  --name <MigrationName>  Name for the new baseline migration (default: InitialCreate)
+  --skip-add              Only clear migration files; do not run 'dotnet ef migrations add'
+  --force                 Skip confirmation prompt
+  -h, --help              Show this help text
+USAGE
+}
+
+log() {
+  echo "[reset-migrations] $*"
+}
+
+confirm_or_exit() {
+  if $FORCE; then
+    return 0
+  fi
+
+  echo "This will permanently delete all files under '$MIGRATIONS_DIR'."
+  read -r -p "Continue? [y/N] " reply
+  case "$reply" in
+    [yY]|[yY][eE][sS]) ;;
+    *) log "Canceled."; exit 0 ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --name)
+      [[ $# -ge 2 ]] || { echo "Missing value for --name" >&2; exit 1; }
+      MIGRATION_NAME="$2"
+      shift 2
+      ;;
+    --skip-add)
+      SKIP_ADD=true
+      shift
+      ;;
+    --force)
+      FORCE=true
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ ! -d "$MIGRATIONS_DIR" ]]; then
+  echo "Migrations directory not found: $MIGRATIONS_DIR" >&2
+  exit 1
+fi
+
+confirm_or_exit
+
+log "Clearing migration files..."
+find "$MIGRATIONS_DIR" -maxdepth 1 -type f -name '*.cs' -delete
+
+if $SKIP_ADD; then
+  log "Done. Migration files were cleared and no new migration was created (--skip-add)."
+  exit 0
+fi
+
+if ! command -v dotnet >/dev/null 2>&1; then
+  echo "dotnet CLI is required but not found in PATH." >&2
+  exit 1
+fi
+
+log "Creating new baseline migration '$MIGRATION_NAME'..."
+dotnet ef migrations add "$MIGRATION_NAME" \
+  --project "$PROJECT" \
+  --startup-project "$STARTUP_PROJECT" \
+  --context "$CONTEXT" \
+  --output-dir Migrations
+
+if [[ -x "./scripts/validate-ef-schema.sh" ]]; then
+  log "Validating that the new migration set has no pending model changes..."
+  ./scripts/validate-ef-schema.sh
+fi
+
+log "Done. New baseline migration created in '$MIGRATIONS_DIR'."


### PR DESCRIPTION
### Motivation

- Make it easier to recreate a baseline EF migration set and keep migration documentation accurate and explicit.
- Simplify maintenance of the migrations project by avoiding manual per-file `Compile` entries in the csproj.
- Provide a safe workflow to clear and regenerate migrations with validation to catch pending model changes early.

### Description

- Added `scripts/reset-migrations.sh`, a CLI script that clears `Tycoon.Backend.Migrations/Migrations` and optionally runs `dotnet ef migrations add` to create a new baseline migration, with options `--name`, `--skip-add`, and `--force` and a confirmation prompt. 
- Updated `README.md` to show the recommended `dotnet ef migrations add` invocation using `--project`, `--startup-project`, `--context`, and `--output-dir`, and added a `Resetting Migrations (Start Over)` section describing the new script and its options. 
- Modified `Tycoon.Backend.Migrations/Tycoon.Backend.Migrations.csproj` to replace an explicit list of migration `Compile` entries with a glob ` <Compile Include="Migrations\**\*.cs" />` so new migration files are picked up automatically.

### Testing

- No automated tests or CI jobs were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0a46ae280832d91708878c4f60d71)