### PR TITLE
Fix Docker build: skip postinstall during npm ci, run build:icons aft…

### DIFF
--- a/docker/Dockerfile.dashboard-vue
+++ b/docker/Dockerfile.dashboard-vue
@@ -3,9 +3,12 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 
 COPY Tycoon.OperatorDashboard.Vue/package.json Tycoon.OperatorDashboard.Vue/package-lock.json* ./
-RUN npm ci || npm install
+RUN npm ci --ignore-scripts || npm install --ignore-scripts
 
 COPY Tycoon.OperatorDashboard.Vue/ .
+
+# Build icons (postinstall can't run during npm ci because source isn't available yet)
+RUN npm run build:icons
 
 # Build args → env vars at build time
 ARG VITE_API_URL


### PR DESCRIPTION
…er source copy

The postinstall script (build:icons) requires source files from src/, but the Dockerfile copies package.json first for layer caching, then source files later. Use --ignore-scripts during npm ci and run build:icons explicitly after COPY.

https://claude.ai/code/session_01SDsso5pKYhum5n8S37jPXA