### PR TITLE
Fix Docker build and CI workflow failures

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -90,7 +90,7 @@ docker-compose.*.override.yml
 
 # =========================
 
-node_modules/
+**/node_modules/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.github/workflows/dotnet-ci.yml
+++ b/.github/workflows/dotnet-ci.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           dotnet-version: '9.0.x'
 
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Restore
         run: dotnet restore
 
@@ -40,6 +43,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '9.0.x'
+
+      - name: Install ripgrep
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Restore
         run: dotnet restore
@@ -91,6 +97,9 @@ jobs:
 
       - name: Restore
         run: dotnet restore
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
 
       - name: Validate EF schema is in sync
         run: bash scripts/validate-ef-schema.sh


### PR DESCRIPTION
Docker:
- Fix .dockerignore: node_modules/ only matched at repo root, not within subdirectories like Tycoon.OperatorDashboard.Vue/. Changed to **/node_modules/ so COPY doesn't overwrite npm-ci-installed packages with local node_modules.

CI (dotnet-ci.yml):
- Add ripgrep (rg) install to build-test and security-contract-tests jobs. check-error-envelope-hardening.sh uses rg which is not pre-installed on ubuntu-latest GitHub Actions runners.
- Add explicit Build step to schema-validation job before running dotnet-ef, so build errors surface clearly instead of being hidden inside EF's implicit build.

https://claude.ai/code/session_01SDsso5pKYhum5n8S37jPXA