### PR TITLE
Fix login 405: rewrite URI in nginx proxy and add ops key header

### DIFF
--- a/Tycoon.OperatorDashboard.Vue/src/lib/auth.ts
+++ b/Tycoon.OperatorDashboard.Vue/src/lib/auth.ts
@@ -4,6 +4,15 @@ import { apiBase } from './config'
 
 const API_BASE = apiBase()
 
+function baseHeaders(): Record<string, string> {
+  const h: Record<string, string> = { 'Content-Type': 'application/json' }
+  const opsKey = import.meta.env.VITE_ADMIN_OPS_KEY as string | undefined
+
+  if (opsKey) h['X-Admin-Ops-Key'] = opsKey
+
+  return h
+}
+
 let accessToken: string | null = null
 let tokenExpiresAt = 0
 let currentAdmin: AdminProfile | null = null
@@ -42,7 +51,7 @@ function clearTokens() {
 export async function login(email: string, password: string): Promise<AdminProfile> {
   const res = await fetch(`${API_BASE}/admin/auth/login`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: baseHeaders(),
     body: JSON.stringify({ email, password }),
   })
 
@@ -82,7 +91,7 @@ export async function refresh(): Promise<boolean> {
   try {
     const res = await fetch(`${API_BASE}/admin/auth/refresh`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: baseHeaders(),
       body: JSON.stringify({ refreshToken }),
     })
 
@@ -124,7 +133,7 @@ export async function fetchProfile(): Promise<AdminProfile | null> {
   if (!token) return null
 
   const res = await fetch(`${API_BASE}/admin/auth/me`, {
-    headers: { Authorization: `Bearer ${token}` },
+    headers: { ...baseHeaders(), Authorization: `Bearer ${token}` },
   })
 
   if (!res.ok) {

--- a/docker/Dockerfile.dashboard-vue
+++ b/docker/Dockerfile.dashboard-vue
@@ -37,7 +37,8 @@ RUN printf 'server {\n\
 \n\
   location /api/backend/ {\n\
     set $upstream http://backend-api:5000;\n\
-    proxy_pass $upstream/;\n\
+    rewrite ^/api/backend/(.*) /$1 break;\n\
+    proxy_pass $upstream;\n\
     proxy_set_header Host $host;\n\
     proxy_set_header X-Real-IP $remote_addr;\n\
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;\n\


### PR DESCRIPTION
Two issues caused login failure:
1. nginx variable-based proxy_pass doesn't strip the location prefix, so backend received /api/backend/admin/auth/login instead of /admin/auth/login → 405. Fixed with explicit rewrite directive.
2. auth.ts used raw fetch without X-Admin-Ops-Key header (which apiClient.ts includes). Added baseHeaders() helper so login, refresh, and profile calls all include the ops key.

https://claude.ai/code/session_01SDsso5pKYhum5n8S37jPXA