### PR TITLE
Rewrite Dockerfile.dashboard to match working API Dockerfile pattern

### DIFF
--- a/docker/Dockerfile.dashboard
+++ b/docker/Dockerfile.dashboard
@@ -1,12 +1,13 @@
-ARG BUILD_CONFIGURATION=Release
-
+# ================================
+# Build Stage - Optimized with layer caching
+# ================================
 FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
-ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
 # Copy Central Package Management files first (rarely change)
 COPY ["Directory.Build.props", "./"]
 COPY ["Directory.Packages.props", "./"]
+COPY ["global.json", "./"]
 
 # Copy project files for restore layer caching
 COPY ["Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj", "Tycoon.OperatorDashboard/"]
@@ -16,18 +17,35 @@ COPY ["Tycoon.Shared/Tycoon.Shared.csproj", "Tycoon.Shared/"]
 
 RUN dotnet restore "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj"
 
+# Copy everything else (source code - changes frequently)
 COPY . .
 
-RUN dotnet build "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj" \
-    -c "${BUILD_CONFIGURATION}" -o /app/build --no-restore
+# Build and publish
+WORKDIR "/src/Tycoon.OperatorDashboard"
+RUN dotnet build "Tycoon.OperatorDashboard.csproj" -c Release --no-restore
 
-FROM build AS publish
-ARG BUILD_CONFIGURATION=Release
-RUN dotnet publish "Tycoon.OperatorDashboard/Tycoon.OperatorDashboard.csproj" \
-    -c "${BUILD_CONFIGURATION}" -o /app/publish /p:UseAppHost=false --no-restore
+RUN dotnet publish "Tycoon.OperatorDashboard.csproj" \
+    -c Release \
+    -o /app/publish \
+    /p:UseAppHost=false \
+    --no-restore
 
+# ================================
+# Runtime Stage - Minimal image
+# ================================
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
 WORKDIR /app
+
+# Install curl for health checks
+RUN apt-get update && \
+    apt-get install -y curl && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /app/publish .
+
 EXPOSE 8200
-COPY --from=publish /app/publish .
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
+    CMD curl -f http://localhost:8200 || exit 1
+
 ENTRYPOINT ["dotnet", "Tycoon.OperatorDashboard.dll"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -517,8 +517,6 @@ services:
     build:
       context: ..
       dockerfile: docker/Dockerfile.dashboard
-      args:
-        BUILD_CONFIGURATION: "${BUILD_CONFIGURATION:-Release}"
     container_name: tycoon_operator_dashboard_blazor
     restart: unless-stopped
     ports:


### PR DESCRIPTION
- Copy global.json before restore for consistent SDK version
- Change WORKDIR to project dir before build (matches Dockerfile.api)
- Remove -o /app/build from build step (unnecessary intermediate output)
- Hardcode -c Release (matches Dockerfile.api, removes shell expansion)
- Install curl in runtime image for health checks
- Add HEALTHCHECK directive
- Remove unused BUILD_CONFIGURATION build arg from compose.yml

https://claude.ai/code/session_01SDsso5pKYhum5n8S37jPXA