### PR TITLE
Fix Blazor dashboard 401 login and data protection key persistence

### DIFF
--- a/Tycoon.OperatorDashboard/Program.cs
+++ b/Tycoon.OperatorDashboard/Program.cs
@@ -42,9 +42,14 @@ builder.Services.AddScoped<AdminAuthService>();
 // Aspire service discovery resolves "http://tycoon-api" via services__tycoon-api__http__0.
 // Standalone: set ApiBaseUrl in appsettings or environment (e.g. "http://localhost:5100").
 var apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? "http://tycoon-api";
+var opsHeaderName = builder.Configuration["AdminOps:Header"] ?? "X-Admin-Ops-Key";
+var opsKey = builder.Configuration["AdminOps:Key"] ?? builder.Configuration["AdminOps__Key"] ?? "";
+
 builder.Services.AddHttpClient("tycoon-api", client =>
 {
     client.BaseAddress = new Uri(apiBaseUrl);
+    if (!string.IsNullOrWhiteSpace(opsKey))
+        client.DefaultRequestHeaders.TryAddWithoutValidation(opsHeaderName, opsKey);
 });
 
 // AdminApiClient is scoped — one shared instance per Blazor Server circuit.

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -527,6 +527,8 @@ services:
       ApiBaseUrl: "http://backend-api:5000"
       AdminOps__Key: "${ADMIN_OPS_KEY:-CHANGE_ME}"
       DataProtection__KeysPath: "/app/dp-keys"
+    volumes:
+      - blazor_dp_keys:/app/dp-keys
     depends_on:
       backend-api:
         condition: service_healthy
@@ -560,3 +562,4 @@ volumes:
   prometheus_data:
   grafana_data:
   letsencrypt:
+  blazor_dp_keys:


### PR DESCRIPTION
1. Add X-Admin-Ops-Key as default header on the HttpClient factory so it's sent on every request including the initial login call (not just after SetToken which requires a successful login first).
2. Add a Docker volume for data protection keys so antiforgery tokens and auth cookies survive container restarts.

https://claude.ai/code/session_01SDsso5pKYhum5n8S37jPXA