### PR TITLE
Synaptix BE Packet A: audit + brand surface reframe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# TycoonTycoon Backend
+# Synaptix Backend
 
-A modern, cloud-native backend API built with .NET 9, designed for scalable multiplayer trivia tycoon game infrastructure with real-time analytics, robust data persistence, and comprehensive observability.
+A modern, cloud-native backend API built with .NET 9, designed for the scalable Synaptix cognitive competition platform with real-time analytics, robust data persistence, and comprehensive observability.
 
 ---
 

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -149,12 +149,12 @@ builder.Services.AddSwaggerGen(c =>
 
     c.SwaggerDoc("v1", new OpenApiInfo
     {
-        Title = "Tycoon Backend API",
+        Title = "Synaptix API",
         Version = "v1",
-        Description = "Trivia Tycoon Game Backend - Multiplayer Quiz Game API",
+        Description = "Platform API for Synaptix gameplay, progression, live competition, and player systems.",
         Contact = new OpenApiContact
         {
-            Name = "Tycoon Development Team"
+            Name = "Synaptix Development Team"
         }
     });
 
@@ -504,9 +504,9 @@ if (app.Environment.IsDevelopment())
 
     app.UseSwaggerUI(c =>
     {
-        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Tycoon Trivia Backend API v1");
+        c.SwaggerEndpoint("/swagger/v1/swagger.json", "Synaptix API v1");
         c.RoutePrefix = "swagger";
-        c.DocumentTitle = "Tycoon API Documentation";
+        c.DocumentTitle = "Synaptix API Documentation";
         c.DisplayRequestDuration();
         c.EnableDeepLinking();
         c.EnableFilter();

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -11,7 +11,7 @@ using Tycoon.Backend.Infrastructure.Persistence.Configurations;
 namespace Tycoon.Backend.Infrastructure.Persistence
 {
     /// <summary>
-    /// Primary EF Core DbContext for Trivia Tycoon (PostgreSQL source of truth).
+    /// Primary EF Core DbContext for Synaptix (PostgreSQL source of truth).
     /// Treat this as the transactional boundary (no UnitOfWork abstraction).
     /// </summary>
     public sealed class AppDb : DbContext, IAppDb

--- a/Tycoon.OperatorDashboard.Vue/index.html
+++ b/Tycoon.OperatorDashboard.Vue/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <link rel="icon" href="/favicon.ico" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Materio - Vuetify Vuejs Admin Template</title>
+  <title>Synaptix Command</title>
   <link rel="stylesheet" type="text/css" href="/loader.css" />
 </head>
 

--- a/Tycoon.OperatorDashboard.Vue/src/layouts/components/DefaultLayoutWithVerticalNav.vue
+++ b/Tycoon.OperatorDashboard.Vue/src/layouts/components/DefaultLayoutWithVerticalNav.vue
@@ -39,7 +39,7 @@ import UserProfile from '@/layouts/components/UserProfile.vue'
         />
 
         <h1 class="font-weight-medium leading-normal text-xl text-uppercase">
-          Tycoon Ops
+          Synaptix Command
         </h1>
       </RouterLink>
 

--- a/Tycoon.OperatorDashboard.Web/src/app/layout.tsx
+++ b/Tycoon.OperatorDashboard.Web/src/app/layout.tsx
@@ -11,8 +11,8 @@ import '@/app/globals.css'
 import '@assets/iconify-icons/generated-icons.css'
 
 export const metadata = {
-  title: 'Tycoon Operator Dashboard',
-  description: 'Admin dashboard for managing the Tycoon platform'
+  title: 'Synaptix Command',
+  description: 'Admin dashboard for managing the Synaptix platform'
 }
 
 const RootLayout = ({ children }: ChildrenType) => {

--- a/Tycoon.OperatorDashboard.Web/src/configs/themeConfig.ts
+++ b/Tycoon.OperatorDashboard.Web/src/configs/themeConfig.ts
@@ -23,7 +23,7 @@ export type Config = {
 }
 
 const themeConfig: Config = {
-  templateName: 'Tycoon Ops',
+  templateName: 'Synaptix Command',
   settingsCookieName: 'tycoon-ops-dashboard',
   mode: 'light', // 'light', 'dark'
   layoutPadding: 24, // Common padding for header, content, footer layout components (in px)

--- a/Tycoon.OperatorDashboard/Components/App.razor
+++ b/Tycoon.OperatorDashboard/Components/App.razor
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Tycoon Operator Dashboard</title>
+    <title>Synaptix Command</title>
     <base href="/" />
     <link rel="stylesheet" href="css/app.css" />
 </head>

--- a/Tycoon.OperatorDashboard/Components/Layout/MainLayout.razor
+++ b/Tycoon.OperatorDashboard/Components/Layout/MainLayout.razor
@@ -7,7 +7,7 @@
 
 <div class="layout">
     <nav class="sidebar">
-        <div class="brand">Tycoon <span>Ops</span></div>
+        <div class="brand">Synaptix <span>Command</span></div>
         <ul>
             <li><a href="/" class="@NavClass("/", exact: true)">
                 <svg xmlns="http://www.w3.org/2000/svg" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>

--- a/Tycoon.OperatorDashboard/Components/Pages/Dashboard.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Dashboard.razor
@@ -27,7 +27,7 @@ else if (_apiConnected == false)
 {
     <div class="api-banner">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg>
-        <span><strong>API unreachable.</strong> Verify the <code>tycoon-api</code> container is running and healthy, then refresh this page.</span>
+        <span><strong>API unreachable.</strong> Verify the <code>synaptix-api</code> container is running and healthy, then refresh this page.</span>
     </div>
 }
 else

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,60 @@
-# Changelog — `claude/add-minio-docker-QBFUx`
+# Changelog
 
-All changes made on this branch relative to `main`.
+All notable changes to this project.
+
+---
+
+## [2026-03-28] Synaptix BE Packet A — Audit + Brand Surface Reframe
+
+### BE-A1: Backend Surface Inventory (Phase 0)
+- Created `docs/backend_surface_inventory.md` — complete audit of all product-visible strings, including Swagger config, dashboard titles, code comments, and documentation headings
+- Created risk register documenting items that must NOT be renamed (namespaces, JWT config, DB names, endpoints, DTOs, CI/CD)
+- Created deferred technical rename list for Packet E
+
+### BE-A2: Brand Surface Reframe (Phase 1)
+
+**Swagger/OpenAPI** (`Tycoon.Backend.Api/Program.cs`):
+- Title: "Tycoon Backend API" → "Synaptix API"
+- Description: "Trivia Tycoon Game Backend - Multiplayer Quiz Game API" → "Platform API for Synaptix gameplay, progression, live competition, and player systems."
+- Contact: "Tycoon Development Team" → "Synaptix Development Team"
+- SwaggerUI endpoint label: "Tycoon Trivia Backend API v1" → "Synaptix API v1"
+- DocumentTitle: "Tycoon API Documentation" → "Synaptix API Documentation"
+
+**Blazor Operator Dashboard** (`Tycoon.OperatorDashboard/`):
+- App title: "Tycoon Operator Dashboard" → "Synaptix Command"
+- Sidebar brand: "Tycoon Ops" → "Synaptix Command"
+- Dashboard API-unreachable banner: "tycoon-api" → "synaptix-api"
+
+**Vue Operator Dashboard** (`Tycoon.OperatorDashboard.Vue/`):
+- HTML title: "Materio - Vuetify Vuejs Admin Template" → "Synaptix Command"
+- Nav header: "Tycoon Ops" → "Synaptix Command"
+
+**Web/React Operator Dashboard** (`Tycoon.OperatorDashboard.Web/`):
+- Layout metadata title: "Tycoon Operator Dashboard" → "Synaptix Command"
+- Layout metadata description: "managing the Tycoon platform" → "managing the Synaptix platform"
+- themeConfig templateName: "Tycoon Ops" → "Synaptix Command"
+
+**Backend Code Comments**:
+- `AppDb.cs` XML doc: "Trivia Tycoon" → "Synaptix"
+
+**Documentation**:
+- `README.md` heading: "TycoonTycoon Backend" → "Synaptix Backend"
+- `README.md` description: updated to reference Synaptix platform
+
+### Separated Migration Plans
+- Created `docs/synaptix_frontend_plan.md` — self-contained Flutter app migration plan (FE Packets A–E)
+- Created `docs/synaptix_backend_plan.md` — self-contained backend migration plan (BE Packets A–E)
+
+### What was NOT changed (by design)
+- `Tycoon.Backend.*` / `Tycoon.Shared.*` namespaces
+- Project names and .csproj files
+- Endpoint paths and DTO field names
+- JWT issuer/audience (`TycoonBackendApi` / `TycoonFrontendApp`)
+- Database names, table names, migration identifiers
+- gRPC proto package (`tycoon.sidecar`)
+- Observability service name (`Tycoon.Backend.Api`)
+- CI/CD pipeline names, Docker image names
+- Cookie/persistence keys (`tycoon-ops-dashboard`)
 
 ---
 

--- a/docs/backend_surface_inventory.md
+++ b/docs/backend_surface_inventory.md
@@ -1,0 +1,89 @@
+# Backend Surface Inventory — Synaptix BE Packet A (Phase 0)
+
+**Date:** 2026-03-28
+**Scope:** All product-visible strings in the TycoonTycoon_Backend repo
+
+---
+
+## 1. Swagger / OpenAPI Configuration
+
+| File | Line(s) | Current Value | Target Value | Risk |
+|---|---|---|---|---|
+| `Tycoon.Backend.Api/Program.cs` | 152 | `Title = "Tycoon Backend API"` | `"Synaptix API"` | Low — display only |
+| `Tycoon.Backend.Api/Program.cs` | 154 | `Description = "Trivia Tycoon Game Backend - Multiplayer Quiz Game API"` | `"Platform API for Synaptix gameplay, progression, live competition, and player systems."` | Low — display only |
+| `Tycoon.Backend.Api/Program.cs` | 157 | `Name = "Tycoon Development Team"` | `"Synaptix Development Team"` | Low — display only |
+| `Tycoon.Backend.Api/Program.cs` | 507 | `"Tycoon Trivia Backend API v1"` (SwaggerUI endpoint label) | `"Synaptix API v1"` | Low — display only |
+| `Tycoon.Backend.Api/Program.cs` | 509 | `DocumentTitle = "Tycoon API Documentation"` | `"Synaptix API Documentation"` | Low — display only |
+
+---
+
+## 2. Blazor Operator Dashboard (Tycoon.OperatorDashboard)
+
+| File | Line(s) | Current Value | Target Value | Risk |
+|---|---|---|---|---|
+| `Components/App.razor` | 6 | `<title>Tycoon Operator Dashboard</title>` | `<title>Synaptix Command</title>` | Low |
+| `Components/Layout/MainLayout.razor` | 10 | `<div class="brand">Tycoon <span>Ops</span></div>` | `<div class="brand">Synaptix <span>Command</span></div>` | Low |
+| `Components/Pages/Dashboard.razor` | 30 | `Verify the <code>tycoon-api</code> container` | `Verify the <code>synaptix-api</code> container` | Low — operator copy only |
+
+---
+
+## 3. Vue Operator Dashboard (Tycoon.OperatorDashboard.Vue)
+
+| File | Line(s) | Current Value | Target Value | Risk |
+|---|---|---|---|---|
+| `index.html` | 8 | `<title>Materio - Vuetify Vuejs Admin Template</title>` | `<title>Synaptix Command</title>` | Low |
+| `src/layouts/components/DefaultLayoutWithVerticalNav.vue` | 41-43 | `Tycoon Ops` | `Synaptix Command` | Low |
+
+---
+
+## 4. Web/React Operator Dashboard (Tycoon.OperatorDashboard.Web)
+
+| File | Line(s) | Current Value | Target Value | Risk |
+|---|---|---|---|---|
+| `src/app/layout.tsx` | 14 | `title: 'Tycoon Operator Dashboard'` | `title: 'Synaptix Command'` | Low |
+| `src/app/layout.tsx` | 15 | `description: 'Admin dashboard for managing the Tycoon platform'` | `description: 'Admin dashboard for managing the Synaptix platform'` | Low |
+| `src/configs/themeConfig.ts` | 26 | `templateName: 'Tycoon Ops'` | `templateName: 'Synaptix Command'` | Low |
+| `src/configs/themeConfig.ts` | 27 | `settingsCookieName: 'tycoon-ops-dashboard'` | Keep as-is (persistence key) | N/A — deferred |
+
+---
+
+## 5. Backend Code Comments
+
+| File | Line(s) | Current Value | Target Value | Risk |
+|---|---|---|---|---|
+| `Tycoon.Backend.Infrastructure/Persistence/AppDb.cs` | 14 | XML comment: `Primary EF Core DbContext for Trivia Tycoon` | `Primary EF Core DbContext for Synaptix` | Low — comment only |
+
+---
+
+## 6. Documentation
+
+| File | Current Value | Target Value | Risk |
+|---|---|---|---|
+| `README.md` line 1 | `# TycoonTycoon Backend` | `# Synaptix Backend` | Low |
+| `README.md` line 3 | `scalable multiplayer trivia tycoon game infrastructure` | `scalable multiplayer Synaptix platform infrastructure` | Low |
+
+---
+
+## 7. DO NOT CHANGE (Risk Register)
+
+These items must remain stable in BE Packet A:
+
+| Item | Location | Reason |
+|---|---|---|
+| `Tycoon.Backend.*` namespaces | All .cs files | Packet E scope — broad compile churn |
+| `Tycoon.OperatorDashboard` project name | .csproj, solution | Packet E scope |
+| `Tycoon.Shared.*` namespaces | Shared libraries | Packet E scope |
+| `package:trivia_tycoon` | N/A (frontend) | Not in this repo |
+| JWT Issuer `TycoonBackendApi` | appsettings.json | Auth contract — breaking change |
+| JWT Audience `TycoonFrontendApp` | appsettings.json | Auth contract — breaking change |
+| ServiceName `Tycoon.Backend.Api` | Observability config | Telemetry pipeline dependency |
+| MongoDB database `tycoon_analytics` | Analytics config | Data pipeline dependency |
+| Elasticsearch aliases `tycoon-qa-*` | Analytics writers | Data pipeline dependency |
+| gRPC package `tycoon.sidecar` | protos/sidecar.proto | Contract — breaking change |
+| HttpClient name `"tycoon-api"` | Dashboard Program.cs | Internal wiring — low visibility |
+| Cookie name `tycoon-ops-dashboard` | themeConfig.ts | Browser persistence key |
+| Endpoint paths | All API endpoints | Contract — breaking change |
+| DTO field names | All DTOs | Contract — breaking change |
+| Database table/column names | EF migrations | Schema — breaking change |
+| CI/CD pipeline names | Build scripts | Deployment dependency |
+| Docker image names | Dockerfiles | Deployment dependency |


### PR DESCRIPTION
Complete BE-A1 (audit) and BE-A2 (brand surface reframe):

- Swagger/OpenAPI: title, description, contact, UI labels -> Synaptix
- Blazor dashboard: title, sidebar brand -> Synaptix Command
- Vue dashboard: HTML title, nav header -> Synaptix Command
- Web/React dashboard: metadata, themeConfig -> Synaptix Command
- AppDb.cs XML doc comment -> Synaptix
- README heading and description -> Synaptix Backend
- Created docs/backend_surface_inventory.md with full audit + risk register
- Updated docs/CHANGELOG.md with detailed change log

No namespace, endpoint, DTO, or persistence key changes (deferred to Packet E).

https://claude.ai/code/session_01D1oSpavFMij2BEEXKfGyGJ