### PR TITLE
Synaptix BE-D1 + BE-C5: complete analytics dimensions and currency te…

### DIFF
--- a/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
@@ -112,6 +112,8 @@ namespace Tycoon.Backend.Api.Features.Analytics
             var synaptixMode = TryGetString(src, "synaptixMode", out var synaptixModeValue) ? synaptixModeValue : null;
             var surface = TryGetString(src, "surface", out var surfaceValue) ? surfaceValue : null;
             var audienceSegment = TryGetString(src, "audienceSegment", out var audienceSegmentValue) ? audienceSegmentValue : null;
+            var entryPoint = TryGetString(src, "entryPoint", out var entryPointValue) ? entryPointValue : null;
+            var brandVersion = TryGetString(src, "brandVersion", out var brandVersionValue) ? brandVersionValue : null;
 
             evt = new QuestionAnsweredAnalyticsEvent(id, matchId, playerId, mode, category, difficulty, isCorrect, answerTimeMs, answeredAtUtc)
             {
@@ -119,7 +121,9 @@ namespace Tycoon.Backend.Api.Features.Analytics
                 PointsAwarded = pointsAwarded,
                 SynaptixMode = synaptixMode,
                 Surface = surface,
-                AudienceSegment = audienceSegment
+                AudienceSegment = audienceSegment,
+                EntryPoint = entryPoint,
+                BrandVersion = brandVersion
             };
 
             return true;

--- a/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredAnalyticsEvent.cs
+++ b/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredAnalyticsEvent.cs
@@ -56,6 +56,10 @@ public sealed class QuestionAnsweredAnalyticsEvent
     public string? Surface { get; set; }
     /// <summary>Audience segment derived from player profile.</summary>
     public string? AudienceSegment { get; set; }
+    /// <summary>Navigation entry point that led to this event (e.g., hub, deep-link, notification).</summary>
+    public string? EntryPoint { get; set; }
+    /// <summary>Brand version identifier for A/B rollout tracking.</summary>
+    public string? BrandVersion { get; set; }
 
     /// <summary>
     /// Copies mutable fields from <paramref name="src"/> onto this instance.
@@ -76,6 +80,8 @@ public sealed class QuestionAnsweredAnalyticsEvent
         SynaptixMode = src.SynaptixMode;
         Surface = src.Surface;
         AudienceSegment = src.AudienceSegment;
+        EntryPoint = src.EntryPoint;
+        BrandVersion = src.BrandVersion;
         UpdatedAtUtc = DateTime.UtcNow;
     }
 }

--- a/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredDailyRollup.cs
+++ b/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredDailyRollup.cs
@@ -18,6 +18,8 @@
         public string? SynaptixMode { get; set; }
         public string? Surface { get; set; }
         public string? AudienceSegment { get; set; }
+        public string? EntryPoint { get; set; }
+        public string? BrandVersion { get; set; }
 
         public int TotalAnswers { get; set; }
         public int CorrectAnswers { get; set; }

--- a/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredPlayerDailyRollup.cs
+++ b/Tycoon.Backend.Application/Analytics/Models/QuestionAnsweredPlayerDailyRollup.cs
@@ -19,6 +19,8 @@
         public string? SynaptixMode { get; set; }
         public string? Surface { get; set; }
         public string? AudienceSegment { get; set; }
+        public string? EntryPoint { get; set; }
+        public string? BrandVersion { get; set; }
 
         public int TotalAnswers { get; set; }
         public int CorrectAnswers { get; set; }

--- a/Tycoon.Backend.Infrastructure/Analytics/Elastic/ElasticAdmin.cs
+++ b/Tycoon.Backend.Infrastructure/Analytics/Elastic/ElasticAdmin.cs
@@ -74,6 +74,8 @@ namespace Tycoon.Backend.Infrastructure.Analytics.Elastic
                             .Keyword("synaptixMode")
                             .Keyword("surface")
                             .Keyword("audienceSegment")
+                            .Keyword("entryPoint")
+                            .Keyword("brandVersion")
                             .LongNumber("totalAnswers")
                             .LongNumber("correctAnswers")
                             .LongNumber("wrongAnswers")
@@ -86,7 +88,7 @@ namespace Tycoon.Backend.Infrastructure.Analytics.Elastic
                         ))
                     )
                     .Priority(500)
-                    .Version(2), ct);
+                    .Version(3), ct);
 
                 if (!put.IsValidResponse)
                 {
@@ -159,6 +161,8 @@ namespace Tycoon.Backend.Infrastructure.Analytics.Elastic
                             .Keyword("synaptixMode")
                             .Keyword("surface")
                             .Keyword("audienceSegment")
+                            .Keyword("entryPoint")
+                            .Keyword("brandVersion")
                             .LongNumber("totalAnswers")
                             .LongNumber("correctAnswers")
                             .LongNumber("wrongAnswers")
@@ -171,7 +175,7 @@ namespace Tycoon.Backend.Infrastructure.Analytics.Elastic
                         ))
                     )
                     .Priority(500)
-                    .Version(2), ct);
+                    .Version(3), ct);
 
                 if (!put.IsValidResponse)
                 {

--- a/Tycoon.OperatorDashboard.Vue/src/pages/economy.vue
+++ b/Tycoon.OperatorDashboard.Vue/src/pages/economy.vue
@@ -18,8 +18,8 @@ const historyPage = ref(1)
 const historyHeaders = [
   { title: 'Event ID', key: 'eventId' },
   { title: 'Kind', key: 'kind' },
-  { title: 'XP', key: 'xp' },
-  { title: 'Coins', key: 'coins' },
+  { title: 'Neural XP', key: 'xp' },
+  { title: 'Credits', key: 'coins' },
   { title: 'Diamonds', key: 'diamonds' },
   { title: 'Date', key: 'createdAtUtc' },
 ]
@@ -238,7 +238,7 @@ async function confirmRollback() {
             >
               <VTextField
                 v-model.number="createForm.xp"
-                label="XP Delta"
+                label="Neural XP Delta"
                 type="number"
               />
             </VCol>
@@ -248,7 +248,7 @@ async function confirmRollback() {
             >
               <VTextField
                 v-model.number="createForm.coins"
-                label="Coins Delta"
+                label="Credits Delta"
                 type="number"
               />
             </VCol>
@@ -284,7 +284,7 @@ async function confirmRollback() {
             type="success"
             class="mt-4"
           >
-            Transaction applied. Balance: XP={{ createResult.balanceXp }}, Coins={{ createResult.balanceCoins }}, Diamonds={{ createResult.balanceDiamonds }}
+            Transaction applied. Balance: Neural XP={{ createResult.balanceXp }}, Credits={{ createResult.balanceCoins }}, Diamonds={{ createResult.balanceDiamonds }}
           </VAlert>
         </VTabsWindowItem>
 
@@ -325,7 +325,7 @@ async function confirmRollback() {
             type="success"
             class="mt-4"
           >
-            Rollback applied. New balance: XP={{ rollbackResult.balanceXp }}, Coins={{ rollbackResult.balanceCoins }}, Diamonds={{ rollbackResult.balanceDiamonds }}
+            Rollback applied. New balance: Neural XP={{ rollbackResult.balanceXp }}, Credits={{ rollbackResult.balanceCoins }}, Diamonds={{ rollbackResult.balanceDiamonds }}
           </VAlert>
         </VTabsWindowItem>
       </VTabsWindow>

--- a/Tycoon.OperatorDashboard.Vue/src/pages/users/[id].vue
+++ b/Tycoon.OperatorDashboard.Vue/src/pages/users/[id].vue
@@ -86,7 +86,7 @@ const unbanLoading = ref(false)
 const severityColors: Record<number, string> = { 2: 'error', 1: 'warning', 0: 'info' }
 const statusLabels: Record<number, string> = { 0: 'Normal', 1: 'Suspected', 2: 'Restricted', 3: 'Banned' }
 const statusColors: Record<number, string> = { 0: 'success', 1: 'warning', 2: 'error', 3: 'error' }
-const currencyLabel: Record<number, string> = { 1: 'XP', 2: 'Coins', 3: 'Diamonds' }
+const currencyLabel: Record<number, string> = { 1: 'Neural XP', 2: 'Credits', 3: 'Diamonds' }
 
 // ─── Loaders ─────────────────────────────────────────────────────────
 async function loadUser() {

--- a/Tycoon.OperatorDashboard.Web/src/views/economy/EconomyView.tsx
+++ b/Tycoon.OperatorDashboard.Web/src/views/economy/EconomyView.tsx
@@ -37,8 +37,8 @@ import { CurrencyType } from '@/lib/types/admin'
 // ─── Helpers ────────────────────────────────────────────────────────
 
 const currencyLabel: Record<number, string> = {
-  [CurrencyType.Xp]: 'XP',
-  [CurrencyType.Coins]: 'Coins',
+  [CurrencyType.Xp]: 'Neural XP',
+  [CurrencyType.Coins]: 'Credits',
   [CurrencyType.Diamonds]: 'Diamonds'
 }
 
@@ -272,7 +272,7 @@ const EconomyView = () => {
                 </Typography>
                 <Box sx={{ display: 'flex', gap: 2 }}>
                   <TextField
-                    label='XP'
+                    label='Neural XP'
                     type='number'
                     value={txnXp}
                     onChange={e => setTxnXp(e.target.value)}
@@ -280,7 +280,7 @@ const EconomyView = () => {
                     sx={{ flex: 1 }}
                   />
                   <TextField
-                    label='Coins'
+                    label='Credits'
                     type='number'
                     value={txnCoins}
                     onChange={e => setTxnCoins(e.target.value)}
@@ -326,7 +326,7 @@ const EconomyView = () => {
                       </Box>
                       {txnResult.status === 1 && (
                         <Typography variant='body2' color='text.secondary'>
-                          Balances — XP: {txnResult.balanceXp}, Coins: {txnResult.balanceCoins}, Diamonds: {txnResult.balanceDiamonds}
+                          Balances — Neural XP: {txnResult.balanceXp}, Credits: {txnResult.balanceCoins}, Diamonds: {txnResult.balanceDiamonds}
                         </Typography>
                       )}
                     </CardContent>
@@ -386,7 +386,7 @@ const EconomyView = () => {
                       </Box>
                       {rollbackResult.status === 1 && (
                         <Typography variant='body2' color='text.secondary'>
-                          Updated balances — XP: {rollbackResult.balanceXp}, Coins: {rollbackResult.balanceCoins}, Diamonds: {rollbackResult.balanceDiamonds}
+                          Updated balances — Neural XP: {rollbackResult.balanceXp}, Credits: {rollbackResult.balanceCoins}, Diamonds: {rollbackResult.balanceDiamonds}
                         </Typography>
                       )}
                     </CardContent>

--- a/Tycoon.OperatorDashboard.Web/src/views/users/UserDetailView.tsx
+++ b/Tycoon.OperatorDashboard.Web/src/views/users/UserDetailView.tsx
@@ -97,7 +97,7 @@ const antiCheatColumns: Column<AntiCheatFlag>[] = [
 
 // ─── Economy Tab ────────────────────────────────────────────────────
 
-const currencyLabel: Record<number, string> = { 1: 'XP', 2: 'Coins', 3: 'Diamonds' }
+const currencyLabel: Record<number, string> = { 1: 'Neural XP', 2: 'Credits', 3: 'Diamonds' }
 
 const economyColumns: Column<EconomyTxnListItem>[] = [
   { id: 'kind', label: 'Kind', render: row => row.kind },

--- a/Tycoon.OperatorDashboard/Components/Pages/Economy.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Economy.razor
@@ -294,7 +294,7 @@ else
     @if (_history.RootElement.TryGetProperty("wallet", out var wallet))
     {
         <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-bottom:1.5rem">
-            @foreach (var (label, key) in new[] { ("Coins", "coins"), ("Diamonds", "diamonds"), ("XP", "xp") })
+            @foreach (var (label, key) in new[] { ("Credits", "coins"), ("Diamonds", "diamonds"), ("Neural XP", "xp") })
             {
                 var val = wallet.TryGetProperty(key, out var v) ? v.GetInt64() : 0;
                 <div class="card" style="text-align:center">
@@ -316,9 +316,9 @@ else
         <h2>Grant Currency</h2>
         <label>Currency type
             <select @bind="_grantType">
-                <option value="coins">Coins</option>
+                <option value="coins">Credits</option>
                 <option value="diamonds">Diamonds</option>
-                <option value="xp">XP</option>
+                <option value="xp">Neural XP</option>
             </select>
         </label>
         <label>Amount<input type="number" @bind="_grantAmount" min="1" /></label>

--- a/Tycoon.OperatorDashboard/Components/Pages/Events.razor
+++ b/Tycoon.OperatorDashboard/Components/Pages/Events.razor
@@ -41,8 +41,8 @@ else
                 </div>
                 <div class="form-row">
                     <label>Scheduled At (UTC)<input type="datetime-local" @bind="_newScheduledAt" /></label>
-                    <label>Entry Fee (coins)<input type="number" @bind="_newEntryFee" min="0" /></label>
-                    <label>Revive Cost (gems)<input type="number" @bind="_newReviveCost" min="0" /></label>
+                    <label>Entry Fee (Credits)<input type="number" @bind="_newEntryFee" min="0" /></label>
+                    <label>Revive Cost (Synapse Shards)<input type="number" @bind="_newReviveCost" min="0" /></label>
                 </div>
                 <button @onclick="CreateAsync">Create Event</button>
                 @if (!string.IsNullOrEmpty(_createMessage))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project.
 
 ---
 
+## [2026-03-31] Synaptix BE Packet D — Analytics & Stabilization (continued)
+
+### BE-D1: Remaining Analytics Dimensions
+- Added `EntryPoint` and `BrandVersion` nullable fields to all 3 analytics models
+- Added JSON extraction for `entryPoint`, `brandVersion` in `AnalyticsEndpoints.cs`
+- Added `.Keyword("entryPoint")`, `.Keyword("brandVersion")` to both Elasticsearch index templates
+- Bumped both template versions to 3
+- All 5 planned Synaptix dimensions now complete: `SynaptixMode`, `Surface`, `AudienceSegment`, `EntryPoint`, `BrandVersion`
+
+### BE-C5: Analytics/Admin Terminology Alignment
+
+**Blazor Operator Dashboard** (`Tycoon.OperatorDashboard/`):
+- `Events.razor`: "Entry Fee (coins)" → "(Credits)", "Revive Cost (gems)" → "(Synapse Shards)"
+- `Economy.razor`: Wallet labels "Coins" → "Credits", "XP" → "Neural XP"
+- `Economy.razor`: Grant currency dropdown "Coins" → "Credits", "XP" → "Neural XP"
+
+**Vue Operator Dashboard** (`Tycoon.OperatorDashboard.Vue/`):
+- `economy.vue`: Table headers "XP" → "Neural XP", "Coins" → "Credits"
+- `economy.vue`: Form labels "XP Delta" → "Neural XP Delta", "Coins Delta" → "Credits Delta"
+- `economy.vue`: Transaction/rollback balance messages updated
+- `users/[id].vue`: Currency labels "XP" → "Neural XP", "Coins" → "Credits"
+
+**Web/React Operator Dashboard** (`Tycoon.OperatorDashboard.Web/`):
+- `EconomyView.tsx`: Currency label map "XP" → "Neural XP", "Coins" → "Credits"
+- `EconomyView.tsx`: Form field labels and balance messages updated
+- `UserDetailView.tsx`: Currency labels "XP" → "Neural XP", "Coins" → "Credits"
+
+**What was NOT changed (by design)**:
+- "Social Accounts" in account-settings — refers to OAuth integrations (Google, Twitter), not Synaptix Circles
+- "Diamonds" — kept as-is per terminology reference (no Synaptix rename defined)
+- API property names (`balanceCoins`, `balanceXp`, etc.) — contract stability
+- Enum values (`CurrencyType.Coins`, etc.) — technical identifiers
+
+---
+
 ## [2026-03-29] Synaptix BE Packet D — Analytics & Stabilization
 
 ### BE-D1: Analytics Dimensions (Phase 6)


### PR DESCRIPTION
…rminology

Add EntryPoint and BrandVersion dimensions (completing all 5 planned Synaptix analytics fields). Align operator dashboard currency labels across all three dashboards: Coins→Credits, XP→Neural XP, gems→Synapse Shards.

https://claude.ai/code/session_01D1oSpavFMij2BEEXKfGyGJ