### PR TITLE
Add player search, unfriend, and career stats endpoints

### DIFF
--- a/Tycoon.Backend.Api/Features/Friends/FriendsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Friends/FriendsEndpoints.cs
@@ -12,6 +12,7 @@ namespace Tycoon.Backend.Api.Features.Friends
     {
         public sealed record SendRequest(Guid FromPlayerId, Guid ToPlayerId);
         public sealed record RespondRequest(Guid PlayerId);
+        public sealed record RemoveFriendRequest(Guid PlayerId, Guid FriendPlayerId);
 
         public static void Map(IEndpointRouteBuilder app)
         {
@@ -81,6 +82,22 @@ namespace Tycoon.Backend.Api.Features.Friends
                 {
                     var res = await friends.ListFriendsAsync(playerId, page, pageSize, ct);
                     return Results.Ok(res);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+            });
+
+            // DELETE /friends/remove
+            g.MapDelete("/remove", async (
+                [FromBody] RemoveFriendRequest req,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                try
+                {
+                    var removed = await friends.RemoveFriendAsync(req.PlayerId, req.FriendPlayerId, ct);
+                    return removed
+                        ? Results.Ok(new { removed = true })
+                        : ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Friendship not found.");
                 }
                 catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
             });

--- a/Tycoon.Backend.Api/Features/Players/PlayersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Players/PlayersEndpoints.cs
@@ -2,6 +2,9 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Application.Players;
 using Tycoon.Backend.Domain.Entities;
 using Tycoon.Backend.Infrastructure.Persistence;
@@ -30,6 +33,78 @@ namespace Tycoon.Backend.Api.Features.Players
                 var dto = await mediator.Send(new GetPlayerById(id), ct);
                 return dto is null ? Results.NotFound() : Results.Ok(dto);
             });
+
+            g.MapGet("/{id:guid}/stats", GetCareerStats).WithOpenApi();
+        }
+
+        private static async Task<IResult> GetCareerStats(
+            Guid id,
+            IAppDb db,
+            CancellationToken ct)
+        {
+            // Verify player exists
+            var playerExists = await db.Players
+                .AsNoTracking()
+                .AnyAsync(p => p.Id == id, ct);
+
+            if (!playerExists)
+                return ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Player not found.");
+
+            var participations = db.MatchParticipantResults
+                .AsNoTracking()
+                .Where(p => p.PlayerId == id);
+
+            var totalMatches = await participations.CountAsync(ct);
+
+            if (totalMatches == 0)
+            {
+                return Results.Ok(new PlayerCareerStatsDto(
+                    PlayerId: id,
+                    TotalMatches: 0,
+                    Wins: 0,
+                    Losses: 0,
+                    WinRate: 0,
+                    TotalCorrect: 0,
+                    TotalWrong: 0,
+                    AvgScore: 0,
+                    AvgAnswerTimeMs: 0
+                ));
+            }
+
+            // Aggregate stats from all match participations
+            var stats = await participations
+                .GroupBy(_ => 1)
+                .Select(g => new
+                {
+                    TotalCorrect = g.Sum(p => p.Correct),
+                    TotalWrong = g.Sum(p => p.Wrong),
+                    AvgScore = g.Average(p => (double)p.Score),
+                    AvgAnswerTimeMs = g.Average(p => p.AvgAnswerTimeMs)
+                })
+                .FirstAsync(ct);
+
+            // Count wins: player had the highest score in their match result
+            var wins = await db.MatchParticipantResults
+                .AsNoTracking()
+                .Where(p => p.PlayerId == id)
+                .Where(p => !db.MatchParticipantResults
+                    .Any(o => o.MatchResultId == p.MatchResultId && o.Score > p.Score))
+                .CountAsync(ct);
+
+            var losses = totalMatches - wins;
+            var winRate = Math.Round((double)wins / totalMatches * 100, 1);
+
+            return Results.Ok(new PlayerCareerStatsDto(
+                PlayerId: id,
+                TotalMatches: totalMatches,
+                Wins: wins,
+                Losses: losses,
+                WinRate: winRate,
+                TotalCorrect: stats.TotalCorrect,
+                TotalWrong: stats.TotalWrong,
+                AvgScore: Math.Round(stats.AvgScore, 1),
+                AvgAnswerTimeMs: Math.Round(stats.AvgAnswerTimeMs, 1)
+            ));
         }
     }
 }

--- a/Tycoon.Backend.Api/Features/Users/UsersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Users/UsersEndpoints.cs
@@ -16,7 +16,39 @@ namespace Tycoon.Backend.Api.Features.Users
                 .WithTags("Users")
                 .RequireAuthorization();
 
+            usersGroup.MapGet("/search", SearchUsers).WithOpenApi();
             usersGroup.MapPatch("/me", UpdateCurrentUserProfile);
+        }
+
+        private static async Task<IResult> SearchUsers(
+            [FromQuery] string handle,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20,
+            IAppDb database = default!,
+            CancellationToken cancellation = default)
+        {
+            if (string.IsNullOrWhiteSpace(handle) || handle.Trim().Length < 2)
+                return ApiResponses.Error(StatusCodes.Status400BadRequest, "INVALID_QUERY",
+                    "Handle search requires at least 2 characters.");
+
+            page = page <= 0 ? 1 : page;
+            pageSize = pageSize is <= 0 or > 50 ? 20 : pageSize;
+
+            var pattern = $"%{handle.Trim()}%";
+
+            var query = database.Users.AsNoTracking()
+                .Where(u => u.IsActive && EF.Functions.ILike(u.Handle, pattern))
+                .OrderBy(u => u.Handle);
+
+            var total = await query.CountAsync(cancellation);
+
+            var items = await query
+                .Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Select(u => new UserSearchResultDto(u.Id, u.Handle, u.Country, u.Tier, u.Mmr))
+                .ToListAsync(cancellation);
+
+            return Results.Ok(new UserSearchResponseDto(page, pageSize, total, items));
         }
 
         private static async Task<IResult> UpdateCurrentUserProfile(

--- a/Tycoon.Backend.Application/Social/FriendsService.cs
+++ b/Tycoon.Backend.Application/Social/FriendsService.cs
@@ -193,6 +193,29 @@ namespace Tycoon.Backend.Application.Social
             return new FriendsListResponseDto(page, pageSize, total, items);
         }
 
+        public async Task<bool> RemoveFriendAsync(Guid playerId, Guid friendPlayerId, CancellationToken ct)
+        {
+            if (playerId == Guid.Empty || friendPlayerId == Guid.Empty)
+                throw new ArgumentException("PlayerId cannot be empty.");
+
+            if (playerId == friendPlayerId)
+                throw new ArgumentException("Cannot unfriend yourself.");
+
+            var edges = await db.FriendEdges
+                .Where(e =>
+                    (e.PlayerId == playerId && e.FriendPlayerId == friendPlayerId) ||
+                    (e.PlayerId == friendPlayerId && e.FriendPlayerId == playerId))
+                .ToListAsync(ct);
+
+            if (edges.Count == 0)
+                return false;
+
+            db.FriendEdges.RemoveRange(edges);
+            await db.SaveChangesAsync(ct);
+
+            return true;
+        }
+
         private async Task EnsureEdgesAsync(Guid a, Guid b, CancellationToken ct)
         {
             // Create A->B if missing

--- a/Tycoon.Shared.Contracts/Dtos/AuthDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/AuthDtos.cs
@@ -28,6 +28,23 @@ namespace Tycoon.Shared.Contracts.Dtos
 
     public record UpdateProfileRequest(string? Handle, string? Country);
 
+    // ===== User Search DTOs =====
+
+    public sealed record UserSearchResultDto(
+        Guid Id,
+        string Handle,
+        string? Country,
+        string? Tier,
+        int Mmr
+    );
+
+    public sealed record UserSearchResponseDto(
+        int Page,
+        int PageSize,
+        int Total,
+        IReadOnlyList<UserSearchResultDto> Items
+    );
+
     // ===== NEW: Signup DTOs =====
 
     /// <summary>

--- a/Tycoon.Shared.Contracts/Dtos/PlayerDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/PlayerDtos.cs
@@ -2,4 +2,16 @@
 {
     public record PlayerDto(Guid Id, string Username, string CountryCode, int Level, double Xp);
     public record CreatePlayerRequest(string Username, string CountryCode);
+
+    public sealed record PlayerCareerStatsDto(
+        Guid PlayerId,
+        int TotalMatches,
+        int Wins,
+        int Losses,
+        double WinRate,
+        int TotalCorrect,
+        int TotalWrong,
+        double AvgScore,
+        double AvgAnswerTimeMs
+    );
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project.
 
 ---
 
+## [2026-04-01] Backend Gaps — Search, Unfriend, Career Stats
+
+### Player Search
+- Added `GET /users/search?handle=&page=&pageSize=` endpoint
+- Case-insensitive partial match via `EF.Functions.ILike`
+- Returns paginated `UserSearchResponseDto` (Id, Handle, Country, Tier, Mmr)
+- Minimum 2 characters required, max 50 results per page
+
+### Unfriend
+- Added `RemoveFriendAsync` to `FriendsService` — deletes both directional edges (A→B and B→A)
+- Added `DELETE /friends/remove` endpoint with `RemoveFriendRequest` body
+- Returns 404 if no friendship exists
+
+### Career Stats
+- Added `GET /players/{id}/stats` endpoint to `PlayersEndpoints`
+- Aggregates from `MatchParticipantResults`: total matches, wins (highest score), losses, win rate, correct/wrong counts, avg score, avg answer time
+- Returns `PlayerCareerStatsDto` with zero-initialized response for players with no match history
+
+---
+
 ## [2026-03-31] Synaptix BE Packet B — Profile Support
 
 ### BE-B1: PlayerPreferences Entity

--- a/docs/synaptix_frontend_integration_guide.md
+++ b/docs/synaptix_frontend_integration_guide.md
@@ -129,6 +129,47 @@ PATCH /users/me   [Requires Authorization]
 ```
 Both fields are optional — only provided fields are updated.
 
+### Search Users
+
+```
+GET /users/search?handle={query}&page=1&pageSize=20   [Requires Authorization]
+```
+Case-insensitive partial match on handle. Minimum 2 characters required, max 50 per page.
+
+**Response:**
+```json
+{
+  "page": 1,
+  "pageSize": 20,
+  "total": 3,
+  "items": [
+    { "id": "guid", "handle": "PlayerName", "country": "US", "tier": "T3", "mmr": 1450 }
+  ]
+}
+```
+Use this for friend discovery / add-friend search.
+
+### Player Career Stats
+
+```
+GET /players/{id}/stats
+```
+**Response:**
+```json
+{
+  "playerId": "guid",
+  "totalMatches": 42,
+  "wins": 28,
+  "losses": 14,
+  "winRate": 66.7,
+  "totalCorrect": 312,
+  "totalWrong": 108,
+  "avgScore": 745.2,
+  "avgAnswerTimeMs": 3420.5
+}
+```
+Returns zeroed stats for players with no match history. Win is defined as highest score in a match.
+
 ---
 
 ## 3. Player Preferences
@@ -582,6 +623,16 @@ Body: `{ "playerId": "guid" }`
 GET /friends?playerId={guid}&page=1&pageSize=25
 ```
 
+### Remove Friend (Unfriend)
+
+```
+DELETE /friends/remove
+```
+```json
+{ "playerId": "guid", "friendPlayerId": "guid" }
+```
+Removes both directional edges. Returns `{ "removed": true }` on success, 404 if no friendship exists.
+
 ### List Friend Requests
 
 ```
@@ -878,7 +929,7 @@ Use these display names in the Flutter app:
 |---|---|---|
 | **EF migration for PlayerPreferences + StoreItem** | Tables don't exist in DB yet — endpoints will 500 until migration runs | Needs `dotnet ef migrations add` in build env |
 | **Store catalog is empty** | `GET /store/catalog` returns 0 items until an admin seeds data | Need admin seeding script or admin endpoint |
-| **No player search** | Cannot search players by handle for friend requests | Backend gap — `GET /users/search?handle=` needed |
+| ~~**No player search**~~ | ~~Cannot search players by handle for friend requests~~ | **DONE** — `GET /users/search?handle=` available |
 | **No IAP receipt validation** | Cannot validate Apple/Google purchase receipts | Backend gap — needs platform-specific receipt checking |
 | **Question bank may be empty** | `GET /questions/set` returns 0 if no questions imported | Use admin bulk import or sidecar `/utilities/questions/import` |
 
@@ -888,8 +939,8 @@ Use these display names in the Flutter app:
 |---|---|---|
 | **Crypto economy layer** | No crypto rewards, wallet linking, or withdrawal | Not started — backend-led |
 | **Cosmetics/avatar system** | No equipped items, banners, or visual customization | Not started |
-| **Profile enrichment** | No career stats summary (W-L, winrate, seasonal rank trend) | Not started |
-| **Unfriend endpoint** | Can add friends but cannot remove them | Quick backend fix needed |
+| ~~**Profile enrichment**~~ | ~~No career stats summary~~ | **DONE** — `GET /players/{id}/stats` available |
+| ~~**Unfriend endpoint**~~ | ~~Can add friends but cannot remove them~~ | **DONE** — `DELETE /friends/remove` available |
 | **ML models** | Churn/difficulty/quality scorers are placeholder rules, not trained models | Sidecar improvement |
 
 ### Does NOT Affect Frontend (Backend-Only)

--- a/docs/synaptix_remaining_work.md
+++ b/docs/synaptix_remaining_work.md
@@ -110,9 +110,9 @@ Source: Full API survey + `synaptix_backend_cross_comparison_status.md` Section 
 - [ ] Optional staking (later phase)
 
 ### Priority 6: Polish & Gaps
-- [ ] Player search/discovery endpoint (`GET /users/search?handle=`)
-- [ ] Profile enrichment (career stats summary, W-L, winrate)
-- [ ] Unfriend endpoint
+- [x] Player search/discovery endpoint (`GET /users/search?handle=`) ✅
+- [x] Profile enrichment / career stats (`GET /players/{id}/stats`) ✅
+- [x] Unfriend endpoint (`DELETE /friends/remove`) ✅
 - [ ] Cosmetics/avatar loadout system
 - [ ] ML model deployment (replace placeholder churn/difficulty/quality scorers)
 


### PR DESCRIPTION
- GET /users/search?handle= with case-insensitive partial match (ILike)
- DELETE /friends/remove with bidirectional edge cleanup
- GET /players/{id}/stats with W-L, winrate, correct/wrong, avg score/time
- Updated frontend integration guide and remaining work docs

https://claude.ai/code/session_01D1oSpavFMij2BEEXKfGyGJ