### PR TITLE
Add on‑prem Cloudflare runbook and Cloudflare Tunnel compose override

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -714,3 +714,17 @@ docker rm tycoon_postgres
 ---
 
 **This file is the single source of truth for Docker usage in this repository.**
+
+---
+
+## 10. On-Prem + Cloudflare Deployment
+
+If you want to run this stack on your own Linux servers (Ubuntu/Fedora) and expose it through Cloudflare, use:
+
+- `docker/compose.yml`
+- `docker/compose.prod.yml`
+- optionally `docker/compose.cloudflare-tunnel.yml` (Cloudflare Tunnel mode)
+
+See the full runbook here:
+
+- `docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md`

--- a/README.md
+++ b/README.md
@@ -726,6 +726,7 @@ GitHub Actions workflow (`.github/workflows/dotnet-ci.yml`) runs on every PR and
 
 ### Infrastructure & Setup
 - **[Docker.md](Docker.md)** - Detailed Docker setup and infrastructure guide
+- **[docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md](docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md)** - On-prem Linux production deployment via Cloudflare DNS or Tunnel
 - **[docs/minio-setup.md](docs/minio-setup.md)** - MinIO bucket setup (console, mc CLI, AWS CLI, .NET SDK)
 - **[docs/backend-migrations-analysis.md](docs/backend-migrations-analysis.md)** - Migration strategy and analysis
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -92,3 +92,6 @@ TRAEFIK_DASHBOARD_PORT=8080
 # Production-only — required when using compose.prod.yml:
 DOMAIN=yourdomain.com
 ACME_EMAIL=admin@yourdomain.com
+# --- Cloudflare Tunnel (optional) ---
+# Used by docker/compose.cloudflare-tunnel.yml
+CLOUDFLARE_TUNNEL_TOKEN=

--- a/docker/compose.cloudflare-tunnel.yml
+++ b/docker/compose.cloudflare-tunnel.yml
@@ -1,0 +1,22 @@
+# Cloudflare Tunnel override for on-prem deployments.
+# Usage:
+#   docker compose \
+#     -f docker/compose.yml \
+#     -f docker/compose.prod.yml \
+#     -f docker/compose.cloudflare-tunnel.yml \
+#     up -d
+
+services:
+  # Cloudflare Tunnel publishes your local Traefik entrypoint to Cloudflare edge
+  # without opening inbound 80/443 on your router/firewall.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: tycoon_cloudflared
+    restart: unless-stopped
+    command: tunnel --no-autoupdate run
+    environment:
+      TUNNEL_TOKEN: "${CLOUDFLARE_TUNNEL_TOKEN:?CLOUDFLARE_TUNNEL_TOKEN is required}"
+    depends_on:
+      traefik:
+        condition: service_started
+    networks: [tycoon-net]

--- a/docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md
+++ b/docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md
@@ -1,0 +1,240 @@
+# On-Prem Linux Deployment with Cloudflare (Ubuntu/Fedora)
+
+This guide helps you run **TycoonTycoon_Backend** on your own Linux server(s), while exposing it safely through Cloudflare.
+
+It supports two edge patterns:
+
+1. **Cloudflare DNS + direct public ingress** (open 80/443 to your server, Traefik handles TLS)
+2. **Cloudflare Tunnel (recommended for home/small office/on-prem)** (no inbound ports required)
+
+---
+
+## 1) Deployment architecture
+
+Recommended production path in this repo:
+
+- `docker/compose.yml` = full stack
+- `docker/compose.prod.yml` = production hardening (no direct DB ports, TLS routing labels, disabled dev tooling)
+- `docker/compose.cloudflare-tunnel.yml` = optional Cloudflare Tunnel sidecar
+
+Traffic flow with Tunnel:
+
+`User -> Cloudflare Edge -> cloudflared container -> Traefik -> backend-api/operator-dashboard`
+
+---
+
+## 2) Host requirements
+
+Minimum host profile (single-node start):
+
+- 4 vCPU
+- 16 GB RAM (Elasticsearch + app stack)
+- 100+ GB SSD
+- Linux kernel with cgroups v2 (modern Ubuntu/Fedora defaults)
+
+Recommended OS packages:
+
+- Docker Engine + Compose plugin
+- `git`, `make`, `curl`, `jq`, `ufw` or `firewalld`
+
+### Ubuntu quick install
+
+```bash
+sudo apt-get update
+sudo apt-get install -y ca-certificates curl gnupg git make jq ufw
+
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo $VERSION_CODENAME) stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+sudo usermod -aG docker "$USER"
+```
+
+### Fedora quick install
+
+```bash
+sudo dnf -y install dnf-plugins-core
+sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
+sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin git make jq
+sudo systemctl enable --now docker
+sudo usermod -aG docker "$USER"
+```
+
+Log out/in after group change.
+
+---
+
+## 3) Clone and configure
+
+```bash
+git clone <your-fork-or-origin-url>
+cd TycoonTycoon_Backend
+cp docker/.env.example docker/.env
+```
+
+Then edit `docker/.env`:
+
+- Replace all default passwords/secrets.
+- Set:
+  - `ASPNETCORE_ENVIRONMENT=Production`
+  - `JWT_SECRET_KEY=<long-random-secret-32+ chars>`
+  - `ADMIN_OPS_KEY=<long-random-secret>`
+  - `SUPER_ADMIN_EMAIL` / `SUPER_ADMIN_PASSWORD`
+  - `DOMAIN=<your-domain>` (for DNS/direct ingress mode)
+  - `ACME_EMAIL=<you@domain>` (for DNS/direct ingress mode)
+  - `CLOUDFLARE_TUNNEL_TOKEN=<token>` (for tunnel mode)
+
+---
+
+## 4) Choose your Cloudflare strategy
+
+## Option A — Cloudflare DNS + direct public ingress
+
+Use when your server can accept inbound `80/tcp` and `443/tcp`.
+
+1. In Cloudflare DNS, add proxied records:
+   - `A`/`AAAA` for `yourdomain.com` -> your public server IP
+   - `A`/`AAAA` for `api.yourdomain.com` -> your public server IP
+2. Keep proxy enabled (orange cloud).
+3. Start stack:
+
+```bash
+docker compose -f docker/compose.yml -f docker/compose.prod.yml up -d --build
+```
+
+4. Confirm containers and cert issuance:
+
+```bash
+docker compose -f docker/compose.yml -f docker/compose.prod.yml ps
+docker logs tycoon_traefik --tail 200
+```
+
+### Firewall (direct ingress)
+
+- Allow: `22`, `80`, `443`
+- Deny public access to data-plane ports (`5432`, `6379`, `27017`, `9200`, etc.)
+
+---
+
+## Option B — Cloudflare Tunnel (recommended)
+
+Use when you **do not** want to open inbound ports.
+
+1. In Cloudflare Zero Trust dashboard:
+   - Create a Tunnel.
+   - Add public hostnames:
+     - `yourdomain.com` -> `http://traefik:80`
+     - `api.yourdomain.com` -> `http://traefik:80`
+   - Copy tunnel token.
+2. Put token in `docker/.env` as `CLOUDFLARE_TUNNEL_TOKEN=...`.
+3. Start stack with tunnel override:
+
+```bash
+docker compose \
+  -f docker/compose.yml \
+  -f docker/compose.prod.yml \
+  -f docker/compose.cloudflare-tunnel.yml \
+  up -d --build
+```
+
+4. Verify tunnel status:
+
+```bash
+docker logs tycoon_cloudflared --tail 200
+```
+
+### Firewall (tunnel mode)
+
+- Allow only `22` (and optional outbound restrictions per policy).
+- No inbound `80/443` required.
+
+---
+
+## 5) First-time migration and health checks
+
+Run migrations explicitly in production:
+
+```bash
+docker compose -f docker/compose.yml -f docker/compose.prod.yml run --rm migration
+```
+
+Check health:
+
+```bash
+docker compose -f docker/compose.yml -f docker/compose.prod.yml ps
+curl -fsS http://localhost:${BACKEND_HTTP_PORT:-5000}/healthz
+```
+
+If API port is not exposed in your final production profile, run health checks from inside the Docker network or through your public domain.
+
+---
+
+## 6) Operational hardening checklist
+
+- Change every secret in `.env` from defaults.
+- Store `.env` in a secret manager if possible (Vault, SOPS, etc.).
+- Enable automatic host security updates.
+- Back up persistent volumes (`postgres_data`, `mongodb_data`, `minio_data`, etc.).
+- Add log shipping/monitoring (Grafana, Prometheus, ELK, or managed equivalent).
+- Restrict SSH (keys only, fail2ban, no root login).
+- Consider Cloudflare Access for operator dashboard (`yourdomain.com`) to enforce SSO/MFA.
+
+---
+
+## 7) Update/rollback workflow
+
+### Update
+
+```bash
+git pull
+docker compose -f docker/compose.yml -f docker/compose.prod.yml pull
+docker compose -f docker/compose.yml -f docker/compose.prod.yml up -d --build
+docker compose -f docker/compose.yml -f docker/compose.prod.yml run --rm migration
+```
+
+(Include `-f docker/compose.cloudflare-tunnel.yml` if tunnel mode is enabled.)
+
+### Rollback
+
+- Revert git commit/tag.
+- Rebuild and redeploy previous image set.
+- Restore DB snapshot if schema-breaking migration was applied.
+
+---
+
+## 8) Fedora vs Ubuntu notes
+
+- Both are valid for production.
+- **Ubuntu LTS** usually has broader hosting/vendor examples.
+- **Fedora** is great for newer kernels/userspace, but plan for more frequent OS updates.
+- For either distro, pin Docker/Compose versions and document a reproducible bootstrap script.
+
+---
+
+## 9) Quick command summary
+
+Direct ingress:
+
+```bash
+docker compose -f docker/compose.yml -f docker/compose.prod.yml up -d --build
+docker compose -f docker/compose.yml -f docker/compose.prod.yml run --rm migration
+```
+
+Cloudflare Tunnel:
+
+```bash
+docker compose \
+  -f docker/compose.yml \
+  -f docker/compose.prod.yml \
+  -f docker/compose.cloudflare-tunnel.yml \
+  up -d --build
+
+docker compose -f docker/compose.yml -f docker/compose.prod.yml run --rm migration
+```


### PR DESCRIPTION
### Motivation
- Provide an operator-friendly on‑prem deployment path that lets operators run the Docker stack on Linux (Ubuntu/Fedora) and expose services through Cloudflare securely. 
- Enable a no‑inbound‑ports option using Cloudflare Tunnel so Traefik/HTTPS can be published without opening 80/443 on the host firewall. 

### Description
- Added an operator runbook `docs/ON_PREM_CLOUDFLARE_DEPLOYMENT.md` describing architecture, host bootstrap (Ubuntu/Fedora), Cloudflare DNS vs Tunnel patterns, migration steps, firewall guidance, and update/rollback procedures. 
- Added a compose override `docker/compose.cloudflare-tunnel.yml` to run `cloudflared` as a sidecar that publishes Traefik to Cloudflare Edge. 
- Extended `docker/.env.example` with `CLOUDFLARE_TUNNEL_TOKEN` and a short comment to document the token use. 
- Linked the new runbook from `README.md` and `Docker.md` so it is discoverable from the existing Docker and repository documentation. 

### Testing
- Ran `git diff --check` to validate whitespace and was clean. 
- Attempted to render the combined compose config with `docker compose -f docker/compose.yml -f docker/compose.prod.yml config` but the command could not be executed in this environment because Docker is not installed (`docker: command not found`). 
- Attempted the same config check including the tunnel override with `CLOUDFLARE_TUNNEL_TOKEN=dummy docker compose -f docker/compose.yml -f docker/compose.prod.yml -f docker/compose.cloudflare-tunnel.yml config` and it also failed for the same reason (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d1be85c18c832da16cb18ba248429a)