### PR TITLE
fix(dashboard): run migrate at startup so Django sessions work in Docker

### DIFF
--- a/Tycoon.OperatorDashboard.Django/operator_dashboard/settings.py
+++ b/Tycoon.OperatorDashboard.Django/operator_dashboard/settings.py
@@ -76,3 +76,9 @@ MINIO_BASE_URL = os.getenv("MINIO_BASE_URL", "http://localhost:9000")
 
 ADMIN_OPS_KEY = os.getenv("ADMIN_OPS_KEY", "")
 LOGIN_URL = "/login"
+
+# Session hardening
+SESSION_COOKIE_HTTPONLY = True
+SESSION_COOKIE_SAMESITE = "Lax"
+SESSION_COOKIE_AGE = 28800  # 8 hours
+SESSION_COOKIE_SECURE = os.getenv("DJANGO_SESSION_COOKIE_SECURE", "false").lower() == "true"

--- a/docker/Dockerfile.dashboard-django
+++ b/docker/Dockerfile.dashboard-django
@@ -10,12 +10,14 @@ COPY Tycoon.OperatorDashboard.Django/requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY Tycoon.OperatorDashboard.Django/ .
+COPY docker/entrypoint-django.sh /entrypoint.sh
 
-RUN python manage.py collectstatic --noinput
+RUN python manage.py collectstatic --noinput \
+ && chmod +x /entrypoint.sh
 
 EXPOSE 8200
 
 HEALTHCHECK --interval=30s --timeout=10s --start-period=20s --retries=3 \
   CMD python -c "import urllib.request; urllib.request.urlopen('http://localhost:8200/healthz', timeout=5)"
 
-CMD ["gunicorn", "operator_dashboard.wsgi:application", "--bind", "0.0.0.0:8200", "--workers", "2", "--timeout", "30"]
+CMD ["/entrypoint.sh"]

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -505,6 +505,9 @@ services:
       MINIO_BASE_URL: "http://minio:9000"
       ADMIN_OPS_KEY: "${ADMIN_OPS_KEY:-CHANGE_ME}"
       API_REQUEST_TIMEOUT_SECONDS: "5"
+      DJANGO_SESSION_COOKIE_SECURE: "false"
+    volumes:
+      - django_db_data:/app
     depends_on:
       backend-api:
         condition: service_healthy
@@ -584,4 +587,5 @@ volumes:
   # `blazor_dp_keys` (for example `operator-dashboard-blazor`).
   blazor_dp_keys:
   sidecar_inference_data:
+  django_db_data:
   letsencrypt:

--- a/docker/entrypoint-django.sh
+++ b/docker/entrypoint-django.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+echo "Running Django migrations..."
+python manage.py migrate --noinput
+
+echo "Starting gunicorn..."
+exec gunicorn operator_dashboard.wsgi:application \
+  --bind 0.0.0.0:8200 \
+  --workers 2 \
+  --timeout 30


### PR DESCRIPTION
The operator dashboard login was failing with a 500 because the default session backend (sessions.backends.db) requires the django_session table, which was never created — the Dockerfile only ran collectstatic.

Changes:
- Add docker/entrypoint-django.sh: runs `migrate --noinput` then execs gunicorn
- Update Dockerfile.dashboard-django to use the entrypoint script
- Mount django_db_data volume in compose.yml so db.sqlite3 persists across restarts
- Add DJANGO_SESSION_COOKIE_SECURE env var to operator-dashboard service
- Harden session cookies in settings.py (HTTPONLY, SAMESITE=Lax, AGE=8h, SECURE from env)

https://claude.ai/code/session_01LtRmfWdjX3HSYeWjpA8aUJ