### PR TITLE
Implement presence system with WebSocket protocol and friend endpoints

### DIFF
--- a/Tycoon.Backend.Api/Features/Users/UserFriendsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Users/UserFriendsEndpoints.cs
@@ -1,0 +1,187 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.EntityFrameworkCore;
+using System.Security.Claims;
+using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Application.Social;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.Users
+{
+    public static class UserFriendsEndpoints
+    {
+        public sealed record SendFriendRequestBody(Guid TargetUserId);
+
+        public static void Map(IEndpointRouteBuilder app)
+        {
+            var g = app.MapGroup("/users/me/friends")
+                .WithTags("Friends")
+                .WithOpenApi()
+                .RequireAuthorization();
+
+            // GET /users/me/friends
+            g.MapGet("", async (
+                HttpContext httpContext,
+                [FromQuery] int page,
+                [FromQuery] int pageSize,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var res = await friends.ListFriendsAsync(playerId, page, pageSize, ct);
+                    return Results.Ok(res);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+            });
+
+            // POST /users/me/friends/request
+            g.MapPost("/request", async (
+                HttpContext httpContext,
+                [FromBody] SendFriendRequestBody req,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var dto = await friends.SendRequestAsync(playerId, req.TargetUserId, ct);
+                    return Results.Ok(dto);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+                catch (InvalidOperationException ex) { return ApiResponses.Error(StatusCodes.Status409Conflict, "CONFLICT", ex.Message); }
+            });
+
+            // GET /users/me/friends/requests  (incoming pending)
+            g.MapGet("/requests", async (
+                HttpContext httpContext,
+                [FromQuery] int page,
+                [FromQuery] int pageSize,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var res = await friends.ListRequestsDetailAsync(playerId, "incoming", page, pageSize, ct);
+                    return Results.Ok(res);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+            });
+
+            // GET /users/me/friends/requests/sent  (outgoing)
+            g.MapGet("/requests/sent", async (
+                HttpContext httpContext,
+                [FromQuery] int page,
+                [FromQuery] int pageSize,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var res = await friends.ListRequestsDetailAsync(playerId, "outgoing", page, pageSize, ct);
+                    return Results.Ok(res);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+            });
+
+            // POST /users/me/friends/requests/{requestId}/accept
+            g.MapPost("/requests/{requestId:guid}/accept", async (
+                Guid requestId,
+                HttpContext httpContext,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var dto = await friends.AcceptRequestAsync(requestId, playerId, ct);
+                    return dto is null
+                        ? ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Friend request not found.")
+                        : Results.Ok(dto);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+                catch (InvalidOperationException ex) { return ApiResponses.Error(StatusCodes.Status409Conflict, "CONFLICT", ex.Message); }
+            });
+
+            // POST /users/me/friends/requests/{requestId}/decline
+            g.MapPost("/requests/{requestId:guid}/decline", async (
+                Guid requestId,
+                HttpContext httpContext,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                try
+                {
+                    var dto = await friends.DeclineRequestAsync(requestId, playerId, ct);
+                    return dto is null
+                        ? ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Friend request not found.")
+                        : Results.Ok(dto);
+                }
+                catch (ArgumentException ex) { return ApiResponses.Error(StatusCodes.Status422UnprocessableEntity, "VALIDATION_ERROR", ex.Message); }
+                catch (InvalidOperationException ex) { return ApiResponses.Error(StatusCodes.Status409Conflict, "CONFLICT", ex.Message); }
+            });
+
+            // GET /users/me/friends/suggestions
+            g.MapGet("/suggestions", async (
+                HttpContext httpContext,
+                IAppDb db,
+                FriendsService friends,
+                CancellationToken ct) =>
+            {
+                if (!TryGetUserId(httpContext, out var playerId))
+                    return ApiResponses.Error(StatusCodes.Status401Unauthorized, "UNAUTHORIZED", "Authentication required.");
+
+                // Collect existing friend IDs to exclude
+                var existingFriendIds = await db.FriendEdges.AsNoTracking()
+                    .Where(e => e.PlayerId == playerId)
+                    .Select(e => e.FriendPlayerId)
+                    .ToListAsync(ct);
+
+                var excluded = new HashSet<Guid>(existingFriendIds) { playerId };
+
+                var suggestions = await db.Users.AsNoTracking()
+                    .Where(u => !excluded.Contains(u.Id) && u.IsActive)
+                    .OrderByDescending(u => u.CreatedAt)
+                    .Take(5)
+                    .Select(u => new FriendSuggestionDto(
+                        u.Id,
+                        u.Handle,
+                        u.Handle,
+                        null,
+                        0,
+                        "New to Synaptix"
+                    ))
+                    .ToListAsync(ct);
+
+                return Results.Ok(suggestions);
+            });
+        }
+
+        private static bool TryGetUserId(HttpContext httpContext, out Guid userId)
+        {
+            userId = Guid.Empty;
+            var claim = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)
+                        ?? httpContext.User.FindFirst("sub");
+            return claim is not null && Guid.TryParse(claim.Value, out userId) && userId != Guid.Empty;
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -2,6 +2,7 @@
 using Hangfire.Dashboard;
 using Hangfire.PostgreSql;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
@@ -18,6 +19,7 @@ using System.Net.WebSockets;
 using System.Reflection;
 using System.Security.Claims;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.RateLimiting;
 using Tycoon.Backend.Api.Features.AdminAnalytics;
@@ -73,6 +75,7 @@ using Tycoon.Backend.Api.Payments.Stripe;
 using Tycoon.Backend.Api.Realtime;
 using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application;
+using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Application.Analytics.Abstractions;
 using Tycoon.Backend.Application.Analytics.Writers;
 using Tycoon.Backend.Application.Auth;
@@ -489,6 +492,7 @@ builder.Services.AddSingleton<IMatchmakingNotifier, SignalRMatchmakingNotifier>(
 builder.Services.AddSingleton<IPartyMatchmakingNotifier, SignalRPartyMatchmakingNotifier>();
 builder.Services.AddSingleton<IConnectionRegistry, ConnectionRegistry>();
 builder.Services.AddSingleton<IPresenceReader, SignalRPresenceReader>();
+builder.Services.AddSingleton<IPresenceSessionManager, PresenceSessionManager>();
 builder.Services.AddSingleton<IGameEventNotifier, SignalRGameEventNotifier>();
 builder.Services.AddSingleton<IGuardianNotifier, SignalRGuardianNotifier>();
 builder.Services.AddSingleton<ITerritoryNotifier, SignalRTerritoryNotifier>();
@@ -663,29 +667,111 @@ app.MapGet("/swagger-debug", () =>
     }
 }).AllowAnonymous().WithTags("Debug");
 
-// WebSocket endpoint
+// WebSocket endpoint — handles presence protocol
 app.Map("/ws", async context =>
 {
-    if (context.WebSockets.IsWebSocketRequest)
-    {
-        using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
-
-        // Send welcome message
-        var welcomeMsg = Encoding.UTF8.GetBytes("{\"op\":\"hello\",\"ts\":" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + "}");
-        await webSocket.SendAsync(
-            new ArraySegment<byte>(welcomeMsg),
-            WebSocketMessageType.Text,
-            true,
-            CancellationToken.None
-        );
-
-        // Keep connection alive
-        await HandleWebSocket(webSocket);
-    }
-    else
+    if (!context.WebSockets.IsWebSocketRequest)
     {
         context.Response.StatusCode = 400;
         await context.Response.WriteAsync("WebSocket connection required");
+        return;
+    }
+
+    var presenceMgr = context.RequestServices.GetRequiredService<IPresenceSessionManager>();
+    var registry = context.RequestServices.GetRequiredService<IConnectionRegistry>();
+    var scopeFactory = context.RequestServices.GetRequiredService<IServiceScopeFactory>();
+
+    // Extract playerId from query string (same pattern as MatchHub)
+    var playerIdStr = context.Request.Query["playerId"].ToString();
+    Guid.TryParse(playerIdStr, out var playerId);
+
+    using var webSocket = await context.WebSockets.AcceptWebSocketAsync();
+
+    // Send hello
+    var helloBytes = Encoding.UTF8.GetBytes("{\"op\":\"hello\",\"ts\":" + DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() + "}");
+    await webSocket.SendAsync(new ArraySegment<byte>(helloBytes), WebSocketMessageType.Text, true, CancellationToken.None);
+
+    var connectedFriendIds = new List<Guid>();
+
+    if (playerId != Guid.Empty)
+    {
+        presenceMgr.Register(playerId, webSocket);
+        registry.Add(playerId, playerIdStr); // use playerIdStr as connectionId for registry compat
+
+        // Load friend IDs and send bulk presence snapshot
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<IAppDb>();
+            connectedFriendIds = await db.FriendEdges
+                .Where(e => e.PlayerId == playerId)
+                .Select(e => e.FriendPlayerId)
+                .ToListAsync(CancellationToken.None);
+        }
+
+        // Send initial bulk snapshot of which friends are online
+        var onlineFriends = presenceMgr.GetConnectedPlayerIds()
+            .Where(id => connectedFriendIds.Contains(id))
+            .Select(id =>
+            {
+                var act = presenceMgr.GetActivity(id);
+                return new
+                {
+                    userId = id.ToString(),
+                    status = act?.Status ?? "online",
+                    activity = act?.Activity,
+                    lastSeen = DateTimeOffset.UtcNow
+                };
+            })
+            .ToList();
+
+        var bulkPayload = JsonSerializer.Serialize(new
+        {
+            op = "presence.bulk",
+            ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            data = new { presences = onlineFriends }
+        });
+        await webSocket.SendAsync(
+            new ArraySegment<byte>(Encoding.UTF8.GetBytes(bulkPayload)),
+            WebSocketMessageType.Text, true, CancellationToken.None);
+
+        // Notify each connected friend that this player is now online
+        var onlineNotify = JsonSerializer.Serialize(new
+        {
+            op = "presence.update",
+            ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            data = new { userId = playerId.ToString(), status = "online", lastSeen = DateTimeOffset.UtcNow }
+        });
+        foreach (var friendId in connectedFriendIds)
+            await presenceMgr.SendToPlayerAsync(friendId, onlineNotify, CancellationToken.None);
+    }
+
+    await HandleWebSocket(webSocket, playerId, connectedFriendIds, presenceMgr, registry, scopeFactory);
+
+    // Cleanup on disconnect
+    if (playerId != Guid.Empty)
+    {
+        presenceMgr.Unregister(playerId);
+        registry.Remove(playerId, playerIdStr);
+
+        // Notify friends this player went offline
+        List<Guid> friendIds2;
+        using (var scope = scopeFactory.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<IAppDb>();
+            friendIds2 = await db.FriendEdges
+                .Where(e => e.PlayerId == playerId)
+                .Select(e => e.FriendPlayerId)
+                .ToListAsync(CancellationToken.None);
+        }
+
+        var offlineMsg = JsonSerializer.Serialize(new
+        {
+            op = "presence.update",
+            ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+            data = new { userId = playerId.ToString(), status = "offline", lastSeen = DateTimeOffset.UtcNow }
+        });
+        foreach (var friendId in friendIds2)
+            await presenceMgr.SendToPlayerAsync(friendId, offlineMsg, CancellationToken.None);
     }
 });
 
@@ -705,6 +791,7 @@ app.MapGrpcService<MobileMatchGrpcService>();
 AnalyticsEndpoints.Map(app);
 AuthEndpoints.Map(app);
 UsersEndpoints.Map(app);
+UserFriendsEndpoints.Map(app);
 PlayerPreferencesEndpoints.Map(app);
 PlayersEndpoints.Map(app);
 MatchesEndpoints.Map(app);
@@ -790,34 +877,145 @@ if (app.Environment.IsDevelopment())
 
 app.Run();
 
-async Task HandleWebSocket(WebSocket webSocket)
+async Task HandleWebSocket(
+    WebSocket webSocket,
+    Guid playerId,
+    List<Guid>? friendIds,
+    IPresenceSessionManager presenceMgr,
+    IConnectionRegistry registry,
+    IServiceScopeFactory scopeFactory)
 {
-    var buffer = new byte[1024 * 4];
+    var buffer = new byte[1024 * 16];
 
     while (webSocket.State == WebSocketState.Open)
     {
-        var result = await webSocket.ReceiveAsync(
-            new ArraySegment<byte>(buffer),
-            CancellationToken.None
-        );
+        WebSocketReceiveResult result;
+        try
+        {
+            result = await webSocket.ReceiveAsync(new ArraySegment<byte>(buffer), CancellationToken.None);
+        }
+        catch (WebSocketException)
+        {
+            break;
+        }
 
         if (result.MessageType == WebSocketMessageType.Close)
         {
-            await webSocket.CloseAsync(
-                WebSocketCloseStatus.NormalClosure,
-                "Closing",
-                CancellationToken.None
-            );
+            await webSocket.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closing", CancellationToken.None);
+            break;
         }
-        else
+
+        if (result.MessageType != WebSocketMessageType.Text || playerId == Guid.Empty)
+            continue;
+
+        var msgText = Encoding.UTF8.GetString(buffer, 0, result.Count);
+
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(msgText); }
+        catch { continue; }
+
+        using (doc)
         {
-            // Echo back for testing
-            await webSocket.SendAsync(
-                new ArraySegment<byte>(buffer, 0, result.Count),
-                result.MessageType,
-                result.EndOfMessage,
-                CancellationToken.None
-            );
+            if (!doc.RootElement.TryGetProperty("op", out var opEl))
+                continue;
+
+            var op = opEl.GetString();
+
+            switch (op)
+            {
+                case "presence.subscribe":
+                {
+                    // Return a bulk snapshot for the requested userIds
+                    List<string> requestedIds = new();
+                    if (doc.RootElement.TryGetProperty("data", out var data) &&
+                        data.TryGetProperty("userIds", out var userIdsEl))
+                    {
+                        foreach (var el in userIdsEl.EnumerateArray())
+                        {
+                            var idStr = el.GetString();
+                            if (idStr is not null) requestedIds.Add(idStr);
+                        }
+                    }
+
+                    var presences = requestedIds
+                        .Where(id => Guid.TryParse(id, out _))
+                        .Select(id =>
+                        {
+                            var pid = Guid.Parse(id);
+                            var act = presenceMgr.GetActivity(pid);
+                            var isOnline = presenceMgr.GetConnectedPlayerIds().Contains(pid);
+                            return new
+                            {
+                                userId = id,
+                                status = isOnline ? (act?.Status ?? "online") : "offline",
+                                activity = act?.Activity,
+                                lastSeen = DateTimeOffset.UtcNow
+                            };
+                        })
+                        .ToList();
+
+                    var bulkResp = JsonSerializer.Serialize(new
+                    {
+                        op = "presence.bulk",
+                        ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        data = new { presences }
+                    });
+                    await webSocket.SendAsync(
+                        new ArraySegment<byte>(Encoding.UTF8.GetBytes(bulkResp)),
+                        WebSocketMessageType.Text, true, CancellationToken.None);
+                    break;
+                }
+
+                case "presence.update":
+                {
+                    // Update this player's activity and broadcast to friends
+                    if (!doc.RootElement.TryGetProperty("data", out var data))
+                        break;
+
+                    var status = data.TryGetProperty("status", out var statusEl) ? statusEl.GetString() : "online";
+                    var activity = data.TryGetProperty("activity", out var actEl) ? actEl.GetString() : null;
+                    JsonElement? gameActivity = data.TryGetProperty("gameActivity", out var gaEl) ? gaEl : null;
+
+                    presenceMgr.SetActivity(playerId, new PresenceActivity(
+                        status ?? "online",
+                        activity,
+                        gameActivity));
+
+                    // Broadcast to friends who are connected
+                    if (friendIds is null)
+                    {
+                        using var scope = scopeFactory.CreateScope();
+                        var db = scope.ServiceProvider.GetRequiredService<IAppDb>();
+                        friendIds = await db.FriendEdges
+                            .Where(e => e.PlayerId == playerId)
+                            .Select(e => e.FriendPlayerId)
+                            .ToListAsync(CancellationToken.None);
+                    }
+
+                    var updateMsg = JsonSerializer.Serialize(new
+                    {
+                        op = "presence.update",
+                        ts = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
+                        data = new
+                        {
+                            userId = playerId.ToString(),
+                            status = status ?? "online",
+                            activity,
+                            gameActivity,
+                            lastSeen = DateTimeOffset.UtcNow
+                        }
+                    });
+
+                    foreach (var friendId in friendIds)
+                        await presenceMgr.SendToPlayerAsync(friendId, updateMsg, CancellationToken.None);
+
+                    break;
+                }
+
+                case "presence.unsubscribe":
+                    // No-op: server routes via friend graph, not per-subscription
+                    break;
+            }
         }
     }
 }

--- a/Tycoon.Backend.Api/Realtime/PresenceSessionManager.cs
+++ b/Tycoon.Backend.Api/Realtime/PresenceSessionManager.cs
@@ -1,0 +1,69 @@
+using System.Collections.Concurrent;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+
+namespace Tycoon.Backend.Api.Realtime
+{
+    public sealed record PresenceActivity(
+        string Status,
+        string? Activity,
+        JsonElement? GameActivity
+    );
+
+    public interface IPresenceSessionManager
+    {
+        void Register(Guid playerId, WebSocket socket);
+        void Unregister(Guid playerId);
+        void SetActivity(Guid playerId, PresenceActivity? activity);
+        PresenceActivity? GetActivity(Guid playerId);
+        Task SendToPlayerAsync(Guid playerId, string json, CancellationToken ct);
+        IReadOnlyCollection<Guid> GetConnectedPlayerIds();
+    }
+
+    public sealed class PresenceSessionManager : IPresenceSessionManager
+    {
+        private readonly ConcurrentDictionary<Guid, (WebSocket Socket, PresenceActivity? Activity)> _sessions = new();
+
+        public void Register(Guid playerId, WebSocket socket)
+            => _sessions[playerId] = (socket, null);
+
+        public void Unregister(Guid playerId)
+            => _sessions.TryRemove(playerId, out _);
+
+        public void SetActivity(Guid playerId, PresenceActivity? activity)
+        {
+            if (_sessions.TryGetValue(playerId, out var entry))
+                _sessions[playerId] = (entry.Socket, activity);
+        }
+
+        public PresenceActivity? GetActivity(Guid playerId)
+            => _sessions.TryGetValue(playerId, out var entry) ? entry.Activity : null;
+
+        public async Task SendToPlayerAsync(Guid playerId, string json, CancellationToken ct)
+        {
+            if (!_sessions.TryGetValue(playerId, out var entry))
+                return;
+
+            if (entry.Socket.State != WebSocketState.Open)
+                return;
+
+            var bytes = Encoding.UTF8.GetBytes(json);
+            try
+            {
+                await entry.Socket.SendAsync(
+                    new ArraySegment<byte>(bytes),
+                    WebSocketMessageType.Text,
+                    endOfMessage: true,
+                    ct);
+            }
+            catch (WebSocketException)
+            {
+                // Connection dropped; will be cleaned up on disconnect
+            }
+        }
+
+        public IReadOnlyCollection<Guid> GetConnectedPlayerIds()
+            => _sessions.Keys.ToArray();
+    }
+}

--- a/Tycoon.Backend.Application/Social/FriendsService.cs
+++ b/Tycoon.Backend.Application/Social/FriendsService.cs
@@ -1,11 +1,12 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Application.Realtime;
 using Tycoon.Backend.Domain.Entities;
 using Tycoon.Shared.Contracts.Dtos;
 
 namespace Tycoon.Backend.Application.Social
 {
-    public sealed class FriendsService(IAppDb db)
+    public sealed class FriendsService(IAppDb db, IPresenceReader presenceReader)
     {
         public async Task<FriendRequestDto> SendRequestAsync(Guid fromPlayerId, Guid toPlayerId, CancellationToken ct)
         {
@@ -185,12 +186,96 @@ namespace Tycoon.Backend.Application.Social
 
             var total = await q.CountAsync(ct);
 
-            var items = await q.Skip((page - 1) * pageSize)
+            // Join with Users to get display names
+            var rows = await q.Skip((page - 1) * pageSize)
                 .Take(pageSize)
-                .Select(x => new FriendDto(x.FriendPlayerId, x.CreatedAtUtc))
+                .Join(db.Users.AsNoTracking(),
+                    edge => edge.FriendPlayerId,
+                    user => user.Id,
+                    (edge, user) => new
+                    {
+                        edge.FriendPlayerId,
+                        user.Handle,
+                        edge.CreatedAtUtc
+                    })
                 .ToListAsync(ct);
 
+            // Check online status for this page of friends
+            var friendIds = rows.Select(r => r.FriendPlayerId).ToList();
+            var onlineIds = await presenceReader.GetOnlineAsync(friendIds, ct);
+            var onlineSet = new HashSet<Guid>(onlineIds);
+
+            var items = rows.Select(r => new FriendDto(
+                FriendPlayerId: r.FriendPlayerId,
+                DisplayName: r.Handle,
+                Username: r.Handle,
+                AvatarUrl: null,
+                IsOnline: onlineSet.Contains(r.FriendPlayerId),
+                LastSeenUtc: null,
+                SinceUtc: r.CreatedAtUtc
+            )).ToList();
+
             return new FriendsListResponseDto(page, pageSize, total, items);
+        }
+
+        public async Task<FriendRequestsDetailListResponseDto> ListRequestsDetailAsync(
+            Guid playerId,
+            string box,
+            int page,
+            int pageSize,
+            CancellationToken ct)
+        {
+            if (playerId == Guid.Empty)
+                throw new ArgumentException("playerId cannot be empty.");
+
+            page = page <= 0 ? 1 : page;
+            pageSize = pageSize is <= 0 or > 200 ? 50 : pageSize;
+
+            var q = db.FriendRequests.AsNoTracking();
+
+            box = (box ?? "all").Trim().ToLowerInvariant();
+            q = box switch
+            {
+                "incoming" => q.Where(x => x.ToPlayerId == playerId && x.Status == "Pending"),
+                "outgoing" => q.Where(x => x.FromPlayerId == playerId),
+                _ => q.Where(x => x.ToPlayerId == playerId || x.FromPlayerId == playerId)
+            };
+
+            q = q.OrderBy(x => x.Status == "Pending" ? 0 : 1)
+                 .ThenByDescending(x => x.CreatedAtUtc);
+
+            var total = await q.CountAsync(ct);
+
+            var rows = await q.Skip((page - 1) * pageSize)
+                .Take(pageSize)
+                .Join(db.Users.AsNoTracking(),
+                    req => req.FromPlayerId,
+                    user => user.Id,
+                    (req, user) => new
+                    {
+                        req.Id,
+                        req.FromPlayerId,
+                        SenderHandle = user.Handle,
+                        req.ToPlayerId,
+                        req.Status,
+                        req.CreatedAtUtc,
+                        req.RespondedAtUtc
+                    })
+                .ToListAsync(ct);
+
+            var items = rows.Select(r => new FriendRequestDetailDto(
+                RequestId: r.Id,
+                FromPlayerId: r.FromPlayerId,
+                SenderDisplayName: r.SenderHandle,
+                SenderUsername: r.SenderHandle,
+                SenderAvatarUrl: null,
+                ToPlayerId: r.ToPlayerId,
+                Status: r.Status,
+                CreatedAtUtc: r.CreatedAtUtc,
+                RespondedAtUtc: r.RespondedAtUtc
+            )).ToList();
+
+            return new FriendRequestsDetailListResponseDto(page, pageSize, total, items);
         }
 
         public async Task RemoveFriendAsync(Guid playerId, Guid friendPlayerId, CancellationToken ct)

--- a/Tycoon.Shared.Contracts/Dtos/SocialDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/SocialDtos.cs
@@ -13,9 +13,36 @@
         DateTimeOffset? RespondedAtUtc
     );
 
+    // Enriched request DTO — includes sender profile for display in the UI
+    public sealed record FriendRequestDetailDto(
+        Guid RequestId,
+        Guid FromPlayerId,
+        string SenderDisplayName,
+        string SenderUsername,
+        string? SenderAvatarUrl,
+        Guid ToPlayerId,
+        string Status,
+        DateTimeOffset CreatedAtUtc,
+        DateTimeOffset? RespondedAtUtc
+    );
+
     public sealed record FriendDto(
         Guid FriendPlayerId,
+        string DisplayName,
+        string Username,
+        string? AvatarUrl,
+        bool IsOnline,
+        DateTimeOffset? LastSeenUtc,
         DateTimeOffset SinceUtc
+    );
+
+    public sealed record FriendSuggestionDto(
+        Guid Id,
+        string DisplayName,
+        string Username,
+        string? AvatarUrl,
+        int MutualFriendCount,
+        string Reason
     );
 
     public sealed record FriendsListResponseDto(
@@ -30,6 +57,13 @@
         int PageSize,
         int Total,
         IReadOnlyList<FriendRequestDto> Items
+    );
+
+    public sealed record FriendRequestsDetailListResponseDto(
+        int Page,
+        int PageSize,
+        int Total,
+        IReadOnlyList<FriendRequestDetailDto> Items
     );
 
     // --- Party ---


### PR DESCRIPTION
## Summary
This PR introduces a real-time presence system for tracking player online status and activity, along with comprehensive friend management endpoints. The implementation includes a WebSocket-based presence protocol, a session manager for handling player connections, and REST endpoints for friend operations.

## Key Changes

### Presence System
- **PresenceSessionManager**: New in-memory session manager that tracks connected players, their WebSocket connections, and activity state
  - Supports registering/unregistering players
  - Stores and retrieves player activity (status, activity, game activity)
  - Broadcasts presence updates to connected players
- **WebSocket Protocol Handler** (`/ws` endpoint):
  - Implements a structured JSON-based presence protocol with operations: `hello`, `presence.bulk`, `presence.update`, `presence.subscribe`, `presence.unsubscribe`
  - Extracts playerId from query string and manages player sessions
  - Sends initial bulk snapshot of online friends on connection
  - Notifies all connected friends when a player comes online/offline
  - Handles incoming presence updates and broadcasts to friend list
  - Graceful error handling for WebSocket exceptions and malformed messages

### Friend Management Endpoints
- **UserFriendsEndpoints**: New REST API group under `/users/me/friends`
  - `GET /users/me/friends` - List friends with pagination and online status
  - `POST /users/me/friends/request` - Send friend request
  - `GET /users/me/friends/requests` - List incoming friend requests
  - `GET /users/me/friends/requests/sent` - List outgoing friend requests
  - `POST /users/me/friends/requests/{requestId}/accept` - Accept request
  - `POST /users/me/friends/requests/{requestId}/decline` - Decline request
  - `GET /users/me/friends/suggestions` - Get friend suggestions (new users)

### Data Transfer Objects
- **FriendRequestDetailDto**: Enriched friend request with sender profile information
- **FriendDto**: Enhanced with display name, username, avatar URL, online status, and last seen timestamp
- **FriendSuggestionDto**: New DTO for friend recommendations
- **FriendRequestsDetailListResponseDto**: Paginated response for detailed friend requests

### Service Updates
- **FriendsService**: 
  - Integrated `IPresenceReader` to check online status
  - Enhanced `ListFriendsAsync` to include display names and online status
  - Added `ListRequestsDetailAsync` for detailed friend request listings with sender information

### Infrastructure
- Added `IPresenceSessionManager` to dependency injection as singleton
- Registered `UserFriendsEndpoints` in the endpoint mapping
- Added necessary using statements for `EntityFrameworkCore` and `System.Text.Json`

## Notable Implementation Details
- Presence updates are broadcast only to players in the requester's friend list (friend graph routing)
- Friend list queries join with Users table to retrieve display names
- Online status is determined by active WebSocket session presence
- Friend request listings support filtering by direction (incoming/outgoing) and status
- All endpoints include proper error handling with standardized API responses
- WebSocket buffer increased from 4KB to 16KB to accommodate larger presence payloads

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2