### PR TITLE
Implement Learning Modules backend to unblock Flutter Learn Hub screens

### DIFF
--- a/LEARNING_MODULES_API_HANDOFF.md
+++ b/LEARNING_MODULES_API_HANDOFF.md
@@ -1,0 +1,334 @@
+# Learning Modules — API Handoff
+
+> **Audience:** Flutter frontend team  
+> **Backend branch:** `claude/review-handoff-plan-4DmaL`  
+> **Base URL:** `http(s)://<host>:5000`  
+> **OpenAPI docs:** `/swagger` (dev only)
+
+---
+
+## Overview
+
+The Learning Hub lets players study trivia content in a guided format and earn XP / Coins on completion. The backend exposes four public player-facing endpoints plus an admin surface.
+
+### Flutter screen → endpoint mapping
+
+| Flutter screen | Endpoint(s) |
+|----------------|-------------|
+| `learn_hub_screen.dart` — Catalogue | `GET /modules` |
+| `module_detail_screen.dart` — Overview | `GET /modules/{id}` |
+| `lesson_screen.dart` — Lesson flow | `GET /modules/{id}/lessons` |
+| `module_complete_screen.dart` — Reward | `POST /modules/{id}/complete` |
+
+---
+
+## Public Endpoints
+
+### `GET /modules` — Browse published modules
+
+**Auth:** None  
+**Query params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `playerId` | `uuid` (optional) | When provided, each item carries `isCompleted: true/false` for that player |
+| `category` | `string` (optional) | Filter by category (exact match, case-sensitive) |
+| `difficulty` | `int` (optional) | `1`=Easy, `2`=Medium, `3`=Hard, `4`=Expert |
+
+**Example request:**
+```
+GET /modules?playerId=a1b2c3d4-…&difficulty=2
+```
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    "title": "Science Basics",
+    "description": "Foundational science questions.",
+    "category": "Science",
+    "difficulty": 1,
+    "lessonCount": 10,
+    "rewardXp": 500,
+    "rewardCoins": 100,
+    "isCompleted": false
+  }
+]
+```
+
+**Notes:**
+- Results ordered by `difficulty ASC`, `title ASC`
+- `isCompleted` is always `false` when `playerId` is omitted
+- Difficulty enum serialises as integer — map with: `1=Easy, 2=Medium, 3=Hard, 4=Expert`
+
+---
+
+### `GET /modules/{id}` — Module overview
+
+**Auth:** None
+
+**Response `200 OK`:**
+```json
+{
+  "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "title": "Science Basics",
+  "description": "Foundational science questions.",
+  "category": "Science",
+  "difficulty": 1,
+  "lessonCount": 10,
+  "rewardXp": 500,
+  "rewardCoins": 100
+}
+```
+
+**Response `404 Not Found`:**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Module not found.",
+    "details": {}
+  }
+}
+```
+
+---
+
+### `GET /modules/{id}/lessons` — Ordered lesson list
+
+**Auth:** None
+
+> **Note on `correctOptionId`:** This field is intentionally exposed on learning endpoints. The learning context is educational — players are supposed to learn the right answers, unlike in competitive gameplay sessions where they are withheld.
+
+**Response `200 OK`:**
+```json
+[
+  {
+    "lessonId": "7c9e6679-7425-40de-944b-e07fc1f90ae7",
+    "order": 1,
+    "questionId": "f47ac10b-58cc-4372-a567-0e02b2c3d479",
+    "questionText": "What is the powerhouse of the cell?",
+    "questionCategory": "Biology",
+    "options": [
+      { "id": "A", "text": "Nucleus" },
+      { "id": "B", "text": "Mitochondria" },
+      { "id": "C", "text": "Ribosome" },
+      { "id": "D", "text": "Golgi Apparatus" }
+    ],
+    "correctOptionId": "B",
+    "explanation": "Mitochondria produce ATP through cellular respiration, earning the nickname 'powerhouse of the cell'."
+  }
+]
+```
+
+**Response `404 Not Found`:** Same shape as above.
+
+**Notes:**
+- Results are ordered by `lesson.order ASC`
+- `explanation` may be `null` if the content team didn't add one for this lesson
+- `options` are ordered by `optionId` (alphabetically: A, B, C, D)
+- `correctOptionId` matches one of the `options[].id` values
+
+**Recommended Flutter lesson flow:**
+1. Display `questionText` + `options` (hide which is correct)
+2. Player taps an option
+3. Reveal: highlight correct option in green, player's wrong selection in red
+4. Show `explanation` text below (if non-null)
+5. Show "Next" button → advance to `order + 1`
+
+---
+
+### `POST /modules/{id}/complete` — Grant completion reward
+
+**Auth:** None (idempotent — safe to call multiple times)  
+**Query params:**
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| `playerId` | `uuid` | Yes | The player claiming the reward |
+
+**Example request:**
+```
+POST /modules/3fa85f64-5717-4562-b3fc-2c963f66afa6/complete?playerId=a1b2c3d4-…
+```
+*(No body required)*
+
+**Response `200 OK` — first completion:**
+```json
+{
+  "moduleId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "playerId": "a1b2c3d4-…",
+  "status": "Completed",
+  "rewardXp": 500,
+  "rewardCoins": 100,
+  "balanceXp": 3500,
+  "balanceCoins": 740
+}
+```
+
+**Response `200 OK` — repeat call (idempotent):**
+```json
+{
+  "moduleId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "playerId": "a1b2c3d4-…",
+  "status": "AlreadyCompleted",
+  "rewardXp": 500,
+  "rewardCoins": 100,
+  "balanceXp": 3500,
+  "balanceCoins": 740
+}
+```
+
+**Response `404 Not Found`:**
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Module not found.",
+    "details": {}
+  }
+}
+```
+
+**`status` field values:**
+
+| Value | Meaning |
+|-------|---------|
+| `"Completed"` | First-time completion — reward was just granted |
+| `"AlreadyCompleted"` | Player already completed this module — no double-grant |
+| `"ModuleNotFound"` | Sent as a `404` response, not in the body |
+
+**Notes:**
+- Call this endpoint after the player finishes the last lesson
+- Show the actual `rewardXp` / `rewardCoins` from the response on the completion screen
+- `balanceXp` / `balanceCoins` are the player's wallet balances _after_ the grant
+- Safe to retry on network failure — the server is idempotent
+
+---
+
+## Difficulty Enum Reference
+
+| Integer | Label | UI colour suggestion |
+|---------|-------|---------------------|
+| `1` | Easy | Green |
+| `2` | Medium | Yellow |
+| `3` | Hard | Orange |
+| `4` | Expert | Red |
+
+---
+
+## Admin Endpoints
+
+All admin endpoints require:
+- `X-Admin-Ops-Key: <key>` header
+- Valid admin JWT with role `admin` + audience `admin-app`
+
+### Create module
+```
+POST /admin/modules
+Content-Type: application/json
+
+{
+  "title": "Science Basics",
+  "description": "Foundational science questions.",
+  "category": "Science",
+  "difficulty": 1,
+  "rewardXp": 500,
+  "rewardCoins": 100
+}
+```
+Response `201 Created`: `{ "id": "<guid>" }`
+
+### Publish / Unpublish
+```
+PATCH /admin/modules/{id}/publish
+PATCH /admin/modules/{id}/unpublish
+```
+Response `200 OK`: `{ "id": "<guid>", "isPublished": true }`
+
+### Add a lesson to a module
+```
+POST /admin/modules/{id}/lessons
+Content-Type: application/json
+
+{
+  "questionId": "<guid>",   // must be an existing Question in the system
+  "order": 1,               // 1-based; must be unique within this module
+  "explanation": "..."      // optional; shown after the player answers
+}
+```
+Response `201 Created`: `{ "lessonId": "<guid>" }`
+
+### Remove a lesson
+```
+DELETE /admin/modules/{id}/lessons/{lessonId}
+```
+Response `204 No Content`
+
+### Update module fields
+```
+PATCH /admin/modules/{id}
+Content-Type: application/json
+
+{
+  "title": "...", "description": "...", "category": "...",
+  "difficulty": 2, "rewardXp": 750, "rewardCoins": 150
+}
+```
+Response `200 OK`: admin module object
+
+### List all modules (including unpublished)
+```
+GET /admin/modules?category=Science&isPublished=true
+```
+
+---
+
+## Database Migration
+
+After pulling this branch, run the EF Core migration to create the three new tables (`learning_modules`, `module_lessons`, `module_completions`):
+
+```bash
+# Via Docker (recommended)
+make migrate
+
+# Or locally (requires .NET 9 SDK + running PostgreSQL)
+dotnet ef migrations add AddLearningModules \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+dotnet ef database update \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+```
+
+---
+
+## Error Response Shape
+
+All errors follow:
+```json
+{
+  "error": {
+    "code": "NOT_FOUND",
+    "message": "Human-readable message.",
+    "details": {}
+  }
+}
+```
+
+| HTTP status | `code` |
+|-------------|--------|
+| `404` | `NOT_FOUND` |
+| `400` | `VALIDATION_ERROR` |
+| `429` | `RATE_LIMITED` |
+
+---
+
+## Questions shared with gameplay
+
+The `Question` records surfaced through lessons are the **same questions** used in competitive matches. Content is not duplicated — `ModuleLesson` just references the `Question.Id` with an optional per-lesson `Explanation`. This means:
+
+- The same question can appear in multiple modules with different explanations
+- Questions must have `Status = "Approved"` to be useful (the API does not filter by status on the lesson endpoint — admin team should only link approved questions)
+- Any question edits made via `/admin/questions` will immediately reflect in lessons

--- a/Tycoon.Backend.Api/Features/AdminLearningModules/AdminLearningModulesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminLearningModules/AdminLearningModulesEndpoints.cs
@@ -1,0 +1,107 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Application.LearningModules;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.AdminLearningModules
+{
+    public static class AdminLearningModulesEndpoints
+    {
+        public static void Map(RouteGroupBuilder admin)
+        {
+            var g = admin.MapGroup("/modules").WithTags("Admin/LearningModules").WithOpenApi();
+
+            // List all modules (including unpublished)
+            g.MapGet("", async (
+                [FromQuery] string? category,
+                [FromQuery] bool? isPublished,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var list = await mediator.Send(
+                    new AdminListLearningModules(category, isPublished), ct);
+                return Results.Ok(list);
+            });
+
+            // Create a new module (starts unpublished)
+            g.MapPost("", async (
+                [FromBody] CreateLearningModuleRequest req,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new AdminCreateLearningModule(req), ct);
+                return Results.Created($"/admin/modules/{dto.Id}", new { id = dto.Id });
+            });
+
+            // Update module fields
+            g.MapPatch("/{id:guid}", async (
+                Guid id,
+                [FromBody] UpdateLearningModuleRequest req,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new AdminUpdateLearningModule(id, req), ct);
+                return dto is null
+                    ? AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found.")
+                    : Results.Ok(dto);
+            });
+
+            // Publish a module (makes it visible to players)
+            g.MapPatch("/{id:guid}/publish", async (
+                Guid id,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var ok = await mediator.Send(new AdminPublishLearningModule(id), ct);
+                return ok
+                    ? Results.Ok(new { id, isPublished = true })
+                    : AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found.");
+            });
+
+            // Unpublish a module (hides from players, keeps data)
+            g.MapPatch("/{id:guid}/unpublish", async (
+                Guid id,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var ok = await mediator.Send(new AdminUnpublishLearningModule(id), ct);
+                return ok
+                    ? Results.Ok(new { id, isPublished = false })
+                    : AdminApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found.");
+            });
+
+            // Add a lesson (question + explanation) to a module
+            g.MapPost("/{id:guid}/lessons", async (
+                Guid id,
+                [FromBody] AddModuleLessonRequest req,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var result = await mediator.Send(new AdminAddLesson(id, req), ct);
+                return result.Success
+                    ? Results.Created($"/admin/modules/{id}/lessons/{result.LessonId}",
+                        new { lessonId = result.LessonId })
+                    : AdminApiResponses.Error(StatusCodes.Status400BadRequest,
+                        "VALIDATION_ERROR", result.Error ?? "Could not add lesson.");
+            });
+
+            // Remove a lesson from a module
+            g.MapDelete("/{id:guid}/lessons/{lessonId:guid}", async (
+                Guid id,
+                Guid lessonId,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var ok = await mediator.Send(new AdminRemoveLesson(id, lessonId), ct);
+                return ok
+                    ? Results.NoContent()
+                    : AdminApiResponses.Error(StatusCodes.Status404NotFound,
+                        "NOT_FOUND", "Lesson not found.");
+            });
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Features/LearningModules/LearningModulesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/LearningModules/LearningModulesEndpoints.cs
@@ -1,0 +1,72 @@
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Tycoon.Backend.Api.Contracts;
+using Tycoon.Backend.Application.LearningModules;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.LearningModules
+{
+    public static class LearningModulesEndpoints
+    {
+        public static void Map(WebApplication app)
+        {
+            var g = app.MapGroup("/modules").WithTags("LearningModules").WithOpenApi();
+
+            // Browse published modules (public)
+            // Optional: ?playerId={guid} populates isCompleted per module
+            // Optional: ?category=Science &difficulty=2
+            g.MapGet("", async (
+                [FromQuery] Guid? playerId,
+                [FromQuery] string? category,
+                [FromQuery] QuestionDifficulty? difficulty,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var list = await mediator.Send(
+                    new ListLearningModules(playerId, category, difficulty), ct);
+                return Results.Ok(list);
+            });
+
+            // Module overview (public)
+            g.MapGet("/{id:guid}", async (Guid id, IMediator mediator, CancellationToken ct) =>
+            {
+                var dto = await mediator.Send(new GetLearningModule(id), ct);
+                return dto is null
+                    ? ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found.")
+                    : Results.Ok(dto);
+            });
+
+            // Ordered lessons with questions + correct answers exposed (learning context)
+            g.MapGet("/{id:guid}/lessons", async (
+                Guid id,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var lessons = await mediator.Send(new GetModuleLessons(id), ct);
+                return lessons is null
+                    ? ApiResponses.Error(StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found.")
+                    : Results.Ok(lessons);
+            });
+
+            // Complete a module and grant reward (idempotent)
+            // POST /modules/{id}/complete?playerId={guid}
+            g.MapPost("/{id:guid}/complete", async (
+                Guid id,
+                [FromQuery] Guid playerId,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var result = await mediator.Send(new CompleteModule(id, playerId), ct);
+
+                return result.Status switch
+                {
+                    "ModuleNotFound" => ApiResponses.Error(
+                        StatusCodes.Status404NotFound, "NOT_FOUND", "Module not found."),
+                    _ => Results.Ok(result)
+                };
+            });
+        }
+    }
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -57,6 +57,8 @@ using Tycoon.Backend.Api.Features.Party;
 using Tycoon.Backend.Api.Features.Players;
 using Tycoon.Backend.Api.Features.Powerups;
 using Tycoon.Backend.Api.Features.Qr;
+using Tycoon.Backend.Api.Features.LearningModules;
+using Tycoon.Backend.Api.Features.AdminLearningModules;
 using Tycoon.Backend.Api.Features.Questions;
 using Tycoon.Backend.Api.Features.Crypto;
 using Tycoon.Backend.Api.Features.Store;
@@ -808,6 +810,7 @@ PartyEndpoints.Map(app);
 RankedLeaderboardsEndpoints.Map(app);
 SeasonRewardsEndpoints.Map(app);
 QuestionsEndpoints.Map(app);
+LearningModulesEndpoints.Map(app);
 VoteEndpoints.Map(app);
 StoreEndpoints.Map(app);
 CryptoEconomyEndpoints.Map(app);
@@ -859,6 +862,7 @@ AdminSeasonLifecycleEndpoints.Map(admin);
 AdminSeasonPointsEndpoints.Map(admin);
 AdminEmailAclEndpoints.Map(admin);
 AdminStoreEndpoints.Map(admin);
+AdminLearningModulesEndpoints.Map(admin);
 
 // Startup logging
 app.Logger.LogInformation("🚀 Tycoon Backend API starting...");

--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -73,6 +73,9 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<PlayerTransactionItem> PlayerTransactionItems { get; }
         DbSet<PlayerPreferences> PlayerPreferences { get; }
         DbSet<StoreItem> StoreItems { get; }
+        DbSet<LearningModule> LearningModules { get; }
+        DbSet<ModuleLesson> ModuleLessons { get; }
+        DbSet<ModuleCompletion> ModuleCompletions { get; }
 
         Task<int> SaveChangesAsync(CancellationToken ct = default);
         EntityEntry Entry(object entity);

--- a/Tycoon.Backend.Application/LearningModules/AdminLearningModuleMutations.cs
+++ b/Tycoon.Backend.Application/LearningModules/AdminLearningModuleMutations.cs
@@ -1,0 +1,238 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.LearningModules
+{
+    // ── Create ───────────────────────────────────────────────────────────────────
+
+    public sealed record AdminCreateLearningModule(CreateLearningModuleRequest Request)
+        : IRequest<AdminLearningModuleListItemDto>;
+
+    public sealed class AdminCreateLearningModuleHandler
+        : IRequestHandler<AdminCreateLearningModule, AdminLearningModuleListItemDto>
+    {
+        private readonly IAppDb _db;
+
+        public AdminCreateLearningModuleHandler(IAppDb db) => _db = db;
+
+        public async Task<AdminLearningModuleListItemDto> Handle(
+            AdminCreateLearningModule request,
+            CancellationToken ct)
+        {
+            var req = request.Request;
+            var module = new LearningModule(
+                req.Title, req.Description, req.Category,
+                req.Difficulty, req.RewardXp, req.RewardCoins);
+
+            _db.LearningModules.Add(module);
+            await _db.SaveChangesAsync(ct);
+
+            return ToDto(module, lessonCount: 0);
+        }
+    }
+
+    // ── Update ───────────────────────────────────────────────────────────────────
+
+    public sealed record AdminUpdateLearningModule(Guid ModuleId, UpdateLearningModuleRequest Request)
+        : IRequest<AdminLearningModuleListItemDto?>;
+
+    public sealed class AdminUpdateLearningModuleHandler
+        : IRequestHandler<AdminUpdateLearningModule, AdminLearningModuleListItemDto?>
+    {
+        private readonly IAppDb _db;
+
+        public AdminUpdateLearningModuleHandler(IAppDb db) => _db = db;
+
+        public async Task<AdminLearningModuleListItemDto?> Handle(
+            AdminUpdateLearningModule request,
+            CancellationToken ct)
+        {
+            var module = await _db.LearningModules
+                .Include(m => m.Lessons)
+                .FirstOrDefaultAsync(m => m.Id == request.ModuleId, ct);
+
+            if (module is null) return null;
+
+            var req = request.Request;
+            module.Update(req.Title, req.Description, req.Category,
+                req.Difficulty, req.RewardXp, req.RewardCoins);
+
+            await _db.SaveChangesAsync(ct);
+            return ToDto(module, module.Lessons.Count);
+        }
+    }
+
+    // ── Publish / Unpublish ───────────────────────────────────────────────────────
+
+    public sealed record AdminPublishLearningModule(Guid ModuleId) : IRequest<bool>;
+
+    public sealed class AdminPublishLearningModuleHandler
+        : IRequestHandler<AdminPublishLearningModule, bool>
+    {
+        private readonly IAppDb _db;
+
+        public AdminPublishLearningModuleHandler(IAppDb db) => _db = db;
+
+        public async Task<bool> Handle(AdminPublishLearningModule request, CancellationToken ct)
+        {
+            var module = await _db.LearningModules.FindAsync(new object[] { request.ModuleId }, ct);
+            if (module is null) return false;
+
+            module.Publish();
+            await _db.SaveChangesAsync(ct);
+            return true;
+        }
+    }
+
+    public sealed record AdminUnpublishLearningModule(Guid ModuleId) : IRequest<bool>;
+
+    public sealed class AdminUnpublishLearningModuleHandler
+        : IRequestHandler<AdminUnpublishLearningModule, bool>
+    {
+        private readonly IAppDb _db;
+
+        public AdminUnpublishLearningModuleHandler(IAppDb db) => _db = db;
+
+        public async Task<bool> Handle(AdminUnpublishLearningModule request, CancellationToken ct)
+        {
+            var module = await _db.LearningModules.FindAsync(new object[] { request.ModuleId }, ct);
+            if (module is null) return false;
+
+            module.Unpublish();
+            await _db.SaveChangesAsync(ct);
+            return true;
+        }
+    }
+
+    // ── Add Lesson ───────────────────────────────────────────────────────────────
+
+    public sealed record AdminAddLesson(Guid ModuleId, AddModuleLessonRequest Request)
+        : IRequest<AdminAddLessonResult>;
+
+    public sealed record AdminAddLessonResult(bool Success, string? Error, Guid? LessonId);
+
+    public sealed class AdminAddLessonHandler
+        : IRequestHandler<AdminAddLesson, AdminAddLessonResult>
+    {
+        private readonly IAppDb _db;
+
+        public AdminAddLessonHandler(IAppDb db) => _db = db;
+
+        public async Task<AdminAddLessonResult> Handle(AdminAddLesson request, CancellationToken ct)
+        {
+            var moduleExists = await _db.LearningModules
+                .AsNoTracking()
+                .AnyAsync(m => m.Id == request.ModuleId, ct);
+
+            if (!moduleExists)
+                return new AdminAddLessonResult(false, "Module not found.", null);
+
+            var questionExists = await _db.Questions
+                .AsNoTracking()
+                .AnyAsync(q => q.Id == request.Request.QuestionId, ct);
+
+            if (!questionExists)
+                return new AdminAddLessonResult(false, "Question not found.", null);
+
+            var lesson = new ModuleLesson(
+                request.ModuleId,
+                request.Request.QuestionId,
+                request.Request.Order,
+                request.Request.Explanation);
+
+            _db.ModuleLessons.Add(lesson);
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException)
+            {
+                return new AdminAddLessonResult(false,
+                    $"A lesson at order {request.Request.Order} already exists in this module.", null);
+            }
+
+            return new AdminAddLessonResult(true, null, lesson.Id);
+        }
+    }
+
+    // ── Remove Lesson ─────────────────────────────────────────────────────────────
+
+    public sealed record AdminRemoveLesson(Guid ModuleId, Guid LessonId) : IRequest<bool>;
+
+    public sealed class AdminRemoveLessonHandler
+        : IRequestHandler<AdminRemoveLesson, bool>
+    {
+        private readonly IAppDb _db;
+
+        public AdminRemoveLessonHandler(IAppDb db) => _db = db;
+
+        public async Task<bool> Handle(AdminRemoveLesson request, CancellationToken ct)
+        {
+            var lesson = await _db.ModuleLessons
+                .FirstOrDefaultAsync(
+                    l => l.Id == request.LessonId && l.ModuleId == request.ModuleId,
+                    ct);
+
+            if (lesson is null) return false;
+
+            _db.ModuleLessons.Remove(lesson);
+            await _db.SaveChangesAsync(ct);
+            return true;
+        }
+    }
+
+    // ── Admin List ────────────────────────────────────────────────────────────────
+
+    public sealed record AdminListLearningModules(string? Category, bool? IsPublished)
+        : IRequest<IReadOnlyList<AdminLearningModuleListItemDto>>;
+
+    public sealed class AdminListLearningModulesHandler
+        : IRequestHandler<AdminListLearningModules, IReadOnlyList<AdminLearningModuleListItemDto>>
+    {
+        private readonly IAppDb _db;
+
+        public AdminListLearningModulesHandler(IAppDb db) => _db = db;
+
+        public async Task<IReadOnlyList<AdminLearningModuleListItemDto>> Handle(
+            AdminListLearningModules request,
+            CancellationToken ct)
+        {
+            var query = _db.LearningModules.AsNoTracking().AsQueryable();
+
+            if (!string.IsNullOrWhiteSpace(request.Category))
+                query = query.Where(m => m.Category == request.Category.Trim());
+
+            if (request.IsPublished.HasValue)
+                query = query.Where(m => m.IsPublished == request.IsPublished.Value);
+
+            var modules = await query
+                .OrderByDescending(m => m.UpdatedAtUtc)
+                .Select(m => new
+                {
+                    m.Id, m.Title, m.Category, m.Difficulty,
+                    LessonCount = m.Lessons.Count,
+                    m.RewardXp, m.RewardCoins,
+                    m.IsPublished, m.CreatedAtUtc, m.UpdatedAtUtc
+                })
+                .ToListAsync(ct);
+
+            return modules
+                .Select(m => new AdminLearningModuleListItemDto(
+                    m.Id, m.Title, m.Category, m.Difficulty,
+                    m.LessonCount, m.RewardXp, m.RewardCoins,
+                    m.IsPublished, m.CreatedAtUtc, m.UpdatedAtUtc))
+                .ToList();
+        }
+    }
+
+    // ── Shared helper ─────────────────────────────────────────────────────────────
+
+    internal static AdminLearningModuleListItemDto ToDto(LearningModule m, int lessonCount) =>
+        new(m.Id, m.Title, m.Category, m.Difficulty,
+            lessonCount, m.RewardXp, m.RewardCoins,
+            m.IsPublished, m.CreatedAtUtc, m.UpdatedAtUtc);
+}

--- a/Tycoon.Backend.Application/LearningModules/CompleteModule.cs
+++ b/Tycoon.Backend.Application/LearningModules/CompleteModule.cs
@@ -1,0 +1,105 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Application.Economy;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.LearningModules
+{
+    public sealed record CompleteModule(Guid ModuleId, Guid PlayerId)
+        : IRequest<CompleteModuleResultDto>;
+
+    public sealed class CompleteModuleHandler
+        : IRequestHandler<CompleteModule, CompleteModuleResultDto>
+    {
+        private readonly IAppDb _db;
+        private readonly EconomyService _economy;
+
+        public CompleteModuleHandler(IAppDb db, EconomyService economy)
+        {
+            _db = db;
+            _economy = economy;
+        }
+
+        public async Task<CompleteModuleResultDto> Handle(
+            CompleteModule request,
+            CancellationToken ct)
+        {
+            // 1. Load module
+            var module = await _db.LearningModules
+                .AsNoTracking()
+                .FirstOrDefaultAsync(m => m.Id == request.ModuleId && m.IsPublished, ct);
+
+            if (module is null)
+                return new CompleteModuleResultDto(
+                    request.ModuleId, request.PlayerId,
+                    "ModuleNotFound", 0, 0, 0, 0);
+
+            // 2. Check for existing completion (idempotent fast path)
+            var existing = await _db.ModuleCompletions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(
+                    c => c.PlayerId == request.PlayerId && c.ModuleId == request.ModuleId,
+                    ct);
+
+            if (existing is not null)
+            {
+                var wallet = await _db.PlayerWallets
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(w => w.PlayerId == request.PlayerId, ct);
+
+                return new CompleteModuleResultDto(
+                    request.ModuleId, request.PlayerId,
+                    "AlreadyCompleted",
+                    module.RewardXp, module.RewardCoins,
+                    wallet?.Xp ?? 0, wallet?.Coins ?? 0);
+            }
+
+            // 3. Create completion record (unique index on (PlayerId, ModuleId) catches races)
+            var completion = new ModuleCompletion(request.PlayerId, request.ModuleId);
+            _db.ModuleCompletions.Add(completion);
+
+            try
+            {
+                await _db.SaveChangesAsync(ct);
+            }
+            catch (DbUpdateException)
+            {
+                // Race: another request beat us — treat as AlreadyCompleted
+                var wallet = await _db.PlayerWallets
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(w => w.PlayerId == request.PlayerId, ct);
+
+                return new CompleteModuleResultDto(
+                    request.ModuleId, request.PlayerId,
+                    "AlreadyCompleted",
+                    module.RewardXp, module.RewardCoins,
+                    wallet?.Xp ?? 0, wallet?.Coins ?? 0);
+            }
+
+            // 4. Grant reward via EconomyService (EventId comes from the completion record)
+            var lines = new List<EconomyLineDto>();
+            if (module.RewardXp > 0)
+                lines.Add(new EconomyLineDto(CurrencyType.Xp, module.RewardXp));
+            if (module.RewardCoins > 0)
+                lines.Add(new EconomyLineDto(CurrencyType.Coins, module.RewardCoins));
+
+            var txnResult = await _economy.ApplyAsync(
+                new CreateEconomyTxnRequest(
+                    EventId: completion.EconomyEventId,
+                    PlayerId: request.PlayerId,
+                    Kind: "module-completion",
+                    Lines: lines,
+                    Note: $"Module: {module.Title}"
+                ),
+                ct);
+
+            return new CompleteModuleResultDto(
+                request.ModuleId, request.PlayerId,
+                "Completed",
+                module.RewardXp, module.RewardCoins,
+                txnResult.BalanceXp, txnResult.BalanceCoins);
+        }
+    }
+}

--- a/Tycoon.Backend.Application/LearningModules/GetLearningModule.cs
+++ b/Tycoon.Backend.Application/LearningModules/GetLearningModule.cs
@@ -1,0 +1,38 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.LearningModules
+{
+    public sealed record GetLearningModule(Guid ModuleId)
+        : IRequest<LearningModuleDetailDto?>;
+
+    public sealed class GetLearningModuleHandler
+        : IRequestHandler<GetLearningModule, LearningModuleDetailDto?>
+    {
+        private readonly IAppDb _db;
+
+        public GetLearningModuleHandler(IAppDb db) => _db = db;
+
+        public async Task<LearningModuleDetailDto?> Handle(
+            GetLearningModule request,
+            CancellationToken ct)
+        {
+            return await _db.LearningModules
+                .AsNoTracking()
+                .Where(m => m.Id == request.ModuleId && m.IsPublished)
+                .Select(m => new LearningModuleDetailDto(
+                    m.Id,
+                    m.Title,
+                    m.Description,
+                    m.Category,
+                    m.Difficulty,
+                    m.Lessons.Count,
+                    m.RewardXp,
+                    m.RewardCoins
+                ))
+                .FirstOrDefaultAsync(ct);
+        }
+    }
+}

--- a/Tycoon.Backend.Application/LearningModules/GetModuleLessons.cs
+++ b/Tycoon.Backend.Application/LearningModules/GetModuleLessons.cs
@@ -1,0 +1,79 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.LearningModules
+{
+    public sealed record GetModuleLessons(Guid ModuleId)
+        : IRequest<IReadOnlyList<ModuleLessonDto>?>;
+
+    public sealed class GetModuleLessonsHandler
+        : IRequestHandler<GetModuleLessons, IReadOnlyList<ModuleLessonDto>?>
+    {
+        private readonly IAppDb _db;
+
+        public GetModuleLessonsHandler(IAppDb db) => _db = db;
+
+        public async Task<IReadOnlyList<ModuleLessonDto>?> Handle(
+            GetModuleLessons request,
+            CancellationToken ct)
+        {
+            // Confirm module exists and is published
+            var moduleExists = await _db.LearningModules
+                .AsNoTracking()
+                .AnyAsync(m => m.Id == request.ModuleId && m.IsPublished, ct);
+
+            if (!moduleExists)
+                return null;
+
+            // Load lessons joined with their questions and options
+            var lessons = await _db.ModuleLessons
+                .AsNoTracking()
+                .Where(l => l.ModuleId == request.ModuleId)
+                .OrderBy(l => l.Order)
+                .Join(
+                    _db.Questions.AsNoTracking(),
+                    lesson => lesson.QuestionId,
+                    question => question.Id,
+                    (lesson, question) => new { lesson, question }
+                )
+                .ToListAsync(ct);
+
+            if (lessons.Count == 0)
+                return Array.Empty<ModuleLessonDto>();
+
+            // Load options for all questions in one query
+            var questionIds = lessons.Select(x => x.question.Id).ToList();
+            var options = await _db.QuestionOptions
+                .AsNoTracking()
+                .Where(o => questionIds.Contains(o.QuestionId))
+                .ToListAsync(ct);
+
+            var optionsByQuestion = options
+                .GroupBy(o => o.QuestionId)
+                .ToDictionary(
+                    g => g.Key,
+                    g => (IReadOnlyList<QuestionOptionDto>)g
+                        .OrderBy(o => o.OptionId)
+                        .Select(o => new QuestionOptionDto(o.OptionId, o.Text))
+                        .ToList()
+                );
+
+            return lessons
+                .Select(x => new ModuleLessonDto(
+                    LessonId: x.lesson.Id,
+                    Order: x.lesson.Order,
+                    QuestionId: x.question.Id,
+                    QuestionText: x.question.Text,
+                    QuestionCategory: x.question.Category,
+                    Options: optionsByQuestion.TryGetValue(x.question.Id, out var opts)
+                        ? opts
+                        : Array.Empty<QuestionOptionDto>(),
+                    CorrectOptionId: x.question.CorrectOptionId,
+                    Explanation: x.lesson.Explanation
+                ))
+                .ToList();
+        }
+    }
+}

--- a/Tycoon.Backend.Application/LearningModules/ListLearningModules.cs
+++ b/Tycoon.Backend.Application/LearningModules/ListLearningModules.cs
@@ -1,0 +1,81 @@
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.LearningModules
+{
+    public sealed record ListLearningModules(
+        Guid? PlayerId,
+        string? Category,
+        QuestionDifficulty? Difficulty
+    ) : IRequest<IReadOnlyList<LearningModuleListItemDto>>;
+
+    public sealed class ListLearningModulesHandler
+        : IRequestHandler<ListLearningModules, IReadOnlyList<LearningModuleListItemDto>>
+    {
+        private readonly IAppDb _db;
+
+        public ListLearningModulesHandler(IAppDb db) => _db = db;
+
+        public async Task<IReadOnlyList<LearningModuleListItemDto>> Handle(
+            ListLearningModules request,
+            CancellationToken ct)
+        {
+            var query = _db.LearningModules
+                .AsNoTracking()
+                .Where(m => m.IsPublished);
+
+            if (!string.IsNullOrWhiteSpace(request.Category))
+                query = query.Where(m => m.Category == request.Category.Trim());
+
+            if (request.Difficulty.HasValue)
+                query = query.Where(m => m.Difficulty == request.Difficulty.Value);
+
+            // Materialise with lesson counts
+            var modules = await query
+                .OrderBy(m => m.Difficulty)
+                .ThenBy(m => m.Title)
+                .Select(m => new
+                {
+                    m.Id,
+                    m.Title,
+                    m.Description,
+                    m.Category,
+                    m.Difficulty,
+                    LessonCount = m.Lessons.Count,
+                    m.RewardXp,
+                    m.RewardCoins
+                })
+                .ToListAsync(ct);
+
+            // Resolve completion state when a player id is provided
+            HashSet<Guid>? completedIds = null;
+            if (request.PlayerId.HasValue)
+            {
+                var ids = modules.Select(m => m.Id).ToList();
+                completedIds = (await _db.ModuleCompletions
+                    .AsNoTracking()
+                    .Where(c => c.PlayerId == request.PlayerId.Value && ids.Contains(c.ModuleId))
+                    .Select(c => c.ModuleId)
+                    .ToListAsync(ct))
+                    .ToHashSet();
+            }
+
+            return modules
+                .Select(m => new LearningModuleListItemDto(
+                    m.Id,
+                    m.Title,
+                    m.Description,
+                    m.Category,
+                    m.Difficulty,
+                    m.LessonCount,
+                    m.RewardXp,
+                    m.RewardCoins,
+                    IsCompleted: completedIds?.Contains(m.Id) ?? false
+                ))
+                .ToList();
+        }
+    }
+}

--- a/Tycoon.Backend.Domain/Entities/LearningModule.cs
+++ b/Tycoon.Backend.Domain/Entities/LearningModule.cs
@@ -1,0 +1,119 @@
+using Tycoon.Backend.Domain.Primitives;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Domain.Entities
+{
+    public sealed class LearningModule : Entity
+    {
+        public string Title { get; private set; } = string.Empty;
+        public string Description { get; private set; } = string.Empty;
+        public string Category { get; private set; } = "General";
+        public QuestionDifficulty Difficulty { get; private set; } = QuestionDifficulty.Easy;
+
+        public int RewardXp { get; private set; }
+        public int RewardCoins { get; private set; }
+
+        public bool IsPublished { get; private set; }
+
+        public DateTimeOffset CreatedAtUtc { get; private set; } = DateTimeOffset.UtcNow;
+        public DateTimeOffset UpdatedAtUtc { get; private set; } = DateTimeOffset.UtcNow;
+
+        public List<ModuleLesson> Lessons { get; private set; } = new();
+
+        private LearningModule() { } // EF
+
+        public LearningModule(
+            string title,
+            string description,
+            string category,
+            QuestionDifficulty difficulty,
+            int rewardXp,
+            int rewardCoins)
+        {
+            SetCore(title, description, category, difficulty, rewardXp, rewardCoins);
+        }
+
+        public void Update(
+            string title,
+            string description,
+            string category,
+            QuestionDifficulty difficulty,
+            int rewardXp,
+            int rewardCoins)
+        {
+            SetCore(title, description, category, difficulty, rewardXp, rewardCoins);
+            UpdatedAtUtc = DateTimeOffset.UtcNow;
+        }
+
+        public void Publish()
+        {
+            IsPublished = true;
+            UpdatedAtUtc = DateTimeOffset.UtcNow;
+        }
+
+        public void Unpublish()
+        {
+            IsPublished = false;
+            UpdatedAtUtc = DateTimeOffset.UtcNow;
+        }
+
+        private void SetCore(
+            string title,
+            string description,
+            string category,
+            QuestionDifficulty difficulty,
+            int rewardXp,
+            int rewardCoins)
+        {
+            Title = title.Trim();
+            Description = description.Trim();
+            Category = string.IsNullOrWhiteSpace(category) ? "General" : category.Trim();
+            Difficulty = difficulty;
+            RewardXp = Math.Max(0, rewardXp);
+            RewardCoins = Math.Max(0, rewardCoins);
+        }
+    }
+
+    public sealed class ModuleLesson
+    {
+        public Guid Id { get; private set; } = Guid.NewGuid();
+        public Guid ModuleId { get; private set; }
+        public Guid QuestionId { get; private set; }
+        public int Order { get; private set; }
+        public string? Explanation { get; private set; }
+
+        private ModuleLesson() { } // EF
+
+        public ModuleLesson(Guid moduleId, Guid questionId, int order, string? explanation)
+        {
+            ModuleId = moduleId;
+            QuestionId = questionId;
+            Order = order;
+            Explanation = string.IsNullOrWhiteSpace(explanation) ? null : explanation.Trim();
+        }
+    }
+
+    public sealed class ModuleCompletion
+    {
+        public Guid Id { get; private set; } = Guid.NewGuid();
+        public Guid PlayerId { get; private set; }
+        public Guid ModuleId { get; private set; }
+
+        /// <summary>
+        /// Stable event id passed to EconomyService.ApplyAsync — stored so re-delivering
+        /// the same completion is idempotent even if the completion row already exists.
+        /// </summary>
+        public Guid EconomyEventId { get; private set; }
+
+        public DateTimeOffset CompletedAtUtc { get; private set; } = DateTimeOffset.UtcNow;
+
+        private ModuleCompletion() { } // EF
+
+        public ModuleCompletion(Guid playerId, Guid moduleId)
+        {
+            PlayerId = playerId;
+            ModuleId = moduleId;
+            EconomyEventId = Guid.NewGuid();
+        }
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -90,6 +90,9 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<PlayerTransactionItem> PlayerTransactionItems => Set<PlayerTransactionItem>();
         public DbSet<PlayerPreferences> PlayerPreferences => Set<PlayerPreferences>();
         public DbSet<StoreItem> StoreItems => Set<StoreItem>();
+        public DbSet<LearningModule> LearningModules => Set<LearningModule>();
+        public DbSet<ModuleLesson> ModuleLessons => Set<ModuleLesson>();
+        public DbSet<ModuleCompletion> ModuleCompletions => Set<ModuleCompletion>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/LearningModuleConfig.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/LearningModuleConfig.cs
@@ -1,0 +1,35 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Entities;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations
+{
+    public sealed class LearningModuleConfig : IEntityTypeConfiguration<LearningModule>
+    {
+        public void Configure(EntityTypeBuilder<LearningModule> b)
+        {
+            b.ToTable("learning_modules");
+            b.HasKey(x => x.Id);
+
+            b.Property(x => x.Title).HasMaxLength(200).IsRequired();
+            b.Property(x => x.Description).HasMaxLength(2000).IsRequired();
+            b.Property(x => x.Category).HasMaxLength(64).IsRequired();
+
+            b.Property(x => x.RewardXp).IsRequired();
+            b.Property(x => x.RewardCoins).IsRequired();
+            b.Property(x => x.IsPublished).IsRequired();
+
+            b.Property(x => x.CreatedAtUtc).IsRequired();
+            b.Property(x => x.UpdatedAtUtc).IsRequired();
+
+            b.HasIndex(x => x.Category);
+            b.HasIndex(x => x.IsPublished);
+            b.HasIndex(x => x.Difficulty);
+
+            b.HasMany(x => x.Lessons)
+                .WithOne()
+                .HasForeignKey(x => x.ModuleId)
+                .OnDelete(DeleteBehavior.Cascade);
+        }
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/ModuleCompletionConfig.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/ModuleCompletionConfig.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Entities;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations
+{
+    public sealed class ModuleCompletionConfig : IEntityTypeConfiguration<ModuleCompletion>
+    {
+        public void Configure(EntityTypeBuilder<ModuleCompletion> b)
+        {
+            b.ToTable("module_completions");
+            b.HasKey(x => x.Id);
+
+            b.Property(x => x.PlayerId).IsRequired();
+            b.Property(x => x.ModuleId).IsRequired();
+            b.Property(x => x.EconomyEventId).IsRequired();
+            b.Property(x => x.CompletedAtUtc).IsRequired();
+
+            // Primary idempotency guard: one completion record per player per module
+            b.HasIndex(x => new { x.PlayerId, x.ModuleId }).IsUnique();
+
+            // Secondary guard: ensures EconomyService EventId is never reused across completions
+            b.HasIndex(x => x.EconomyEventId).IsUnique();
+
+            b.HasIndex(x => x.PlayerId);
+            b.HasIndex(x => x.ModuleId);
+        }
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/ModuleLessonConfig.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/ModuleLessonConfig.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Entities;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations
+{
+    public sealed class ModuleLessonConfig : IEntityTypeConfiguration<ModuleLesson>
+    {
+        public void Configure(EntityTypeBuilder<ModuleLesson> b)
+        {
+            b.ToTable("module_lessons");
+            b.HasKey(x => x.Id);
+
+            b.Property(x => x.ModuleId).IsRequired();
+            b.Property(x => x.QuestionId).IsRequired();
+            b.Property(x => x.Order).IsRequired();
+            b.Property(x => x.Explanation).HasMaxLength(2000);
+
+            b.HasIndex(x => x.ModuleId);
+            b.HasIndex(x => x.QuestionId);
+
+            // Prevent duplicate ordering within a module
+            b.HasIndex(x => new { x.ModuleId, x.Order }).IsUnique();
+        }
+    }
+}

--- a/Tycoon.Shared.Contracts/Dtos/LearningModuleDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/LearningModuleDtos.cs
@@ -1,0 +1,97 @@
+namespace Tycoon.Shared.Contracts.Dtos
+{
+    // ── Browse / list ────────────────────────────────────────────────────────────
+
+    public sealed record LearningModuleListItemDto(
+        Guid Id,
+        string Title,
+        string Description,
+        string Category,
+        QuestionDifficulty Difficulty,
+        int LessonCount,
+        int RewardXp,
+        int RewardCoins,
+        bool IsCompleted        // false when no playerId is supplied to the endpoint
+    );
+
+    // ── Module overview (single) ─────────────────────────────────────────────────
+
+    public sealed record LearningModuleDetailDto(
+        Guid Id,
+        string Title,
+        string Description,
+        string Category,
+        QuestionDifficulty Difficulty,
+        int LessonCount,
+        int RewardXp,
+        int RewardCoins
+    );
+
+    // ── Lesson (learning screen) ─────────────────────────────────────────────────
+    // CorrectOptionId is intentionally exposed — this is a learning context,
+    // not a competitive gameplay context.
+
+    public sealed record ModuleLessonDto(
+        Guid LessonId,
+        int Order,
+        Guid QuestionId,
+        string QuestionText,
+        string QuestionCategory,
+        IReadOnlyList<QuestionOptionDto> Options,   // reuses existing QuestionOptionDto
+        string CorrectOptionId,
+        string? Explanation
+    );
+
+    // ── Complete response ────────────────────────────────────────────────────────
+
+    public sealed record CompleteModuleResultDto(
+        Guid ModuleId,
+        Guid PlayerId,
+        string Status,          // "Completed" | "AlreadyCompleted" | "ModuleNotFound"
+        int RewardXp,
+        int RewardCoins,
+        int BalanceXp,
+        int BalanceCoins
+    );
+
+    // ── Admin requests ───────────────────────────────────────────────────────────
+
+    public sealed record CreateLearningModuleRequest(
+        string Title,
+        string Description,
+        string Category,
+        QuestionDifficulty Difficulty,
+        int RewardXp,
+        int RewardCoins
+    );
+
+    public sealed record UpdateLearningModuleRequest(
+        string Title,
+        string Description,
+        string Category,
+        QuestionDifficulty Difficulty,
+        int RewardXp,
+        int RewardCoins
+    );
+
+    public sealed record AddModuleLessonRequest(
+        Guid QuestionId,
+        int Order,
+        string? Explanation
+    );
+
+    // ── Admin list item ──────────────────────────────────────────────────────────
+
+    public sealed record AdminLearningModuleListItemDto(
+        Guid Id,
+        string Title,
+        string Category,
+        QuestionDifficulty Difficulty,
+        int LessonCount,
+        int RewardXp,
+        int RewardCoins,
+        bool IsPublished,
+        DateTimeOffset CreatedAtUtc,
+        DateTimeOffset UpdatedAtUtc
+    );
+}


### PR DESCRIPTION
- Domain: LearningModule (Entity), ModuleLesson, ModuleCompletion with double-idempotency guard (unique index on PlayerId+ModuleId and EconomyEventId)
- EF configs: learning_modules, module_lessons, module_completions tables
- Shared DTOs: LearningModuleDtos.cs (list, detail, lesson, complete, admin shapes)
- Handlers: ListLearningModules, GetLearningModule, GetModuleLessons, CompleteModule (routes reward through EconomyService.ApplyAsync with kind="module-completion")
- Admin handlers: create, update, publish/unpublish, add/remove lessons, list
- Public endpoints: GET /modules, GET /modules/{id}, GET /modules/{id}/lessons, POST /modules/{id}/complete (idempotent, playerId via query param)
- Admin endpoints: full CRUD under /admin/modules (protected by existing admin group)
- LEARNING_MODULES_API_HANDOFF.md: frontend team API contract document with full request/response shapes, Flutter screen→endpoint mapping, and migration steps

Migration to run: dotnet ef migrations add AddLearningModules

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2