### PR TITLE
Add MinIO-backed catalog seeders for StoreItems, SkillNodes, SeasonRe…

### DIFF
--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -81,6 +81,7 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<PlayerTransactionItem> PlayerTransactionItems { get; }
         DbSet<PlayerPreferences> PlayerPreferences { get; }
         DbSet<StoreItem> StoreItems { get; }
+        DbSet<SeasonRewardRule> SeasonRewardRules { get; }
         DbSet<LearningModule> LearningModules { get; }
         DbSet<ModuleLesson> ModuleLessons { get; }
         DbSet<ModuleCompletion> ModuleCompletions { get; }

--- a/Tycoon.Backend.Application/Abstractions/IObjectStorage.cs
+++ b/Tycoon.Backend.Application/Abstractions/IObjectStorage.cs
@@ -4,5 +4,6 @@ namespace Tycoon.Backend.Application.Abstractions
     {
         Task PutAsync(string key, Stream content, string contentType, long size = -1, CancellationToken ct = default);
         string GetPublicUrl(string key);
+        Task<Stream?> GetAsync(string key, CancellationToken ct = default);
     }
 }

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -98,6 +98,7 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<PlayerTransactionItem> PlayerTransactionItems => Set<PlayerTransactionItem>();
         public DbSet<PlayerPreferences> PlayerPreferences => Set<PlayerPreferences>();
         public DbSet<StoreItem> StoreItems => Set<StoreItem>();
+        public DbSet<SeasonRewardRule> SeasonRewardRules => Set<SeasonRewardRule>();
         public DbSet<LearningModule> LearningModules => Set<LearningModule>();
         public DbSet<ModuleLesson> ModuleLessons => Set<ModuleLesson>();
         public DbSet<ModuleCompletion> ModuleCompletions => Set<ModuleCompletion>();

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/SeasonRewardRuleConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/SeasonRewardRuleConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Entities;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations
+{
+    public sealed class SeasonRewardRuleConfiguration : IEntityTypeConfiguration<SeasonRewardRule>
+    {
+        public void Configure(EntityTypeBuilder<SeasonRewardRule> builder)
+        {
+            builder.HasKey(x => x.Id);
+
+            builder.HasIndex(x => new { x.Tier, x.MaxTierRank }).IsUnique();
+
+            builder.Property(x => x.Tier).IsRequired();
+            builder.Property(x => x.MaxTierRank).IsRequired();
+            builder.Property(x => x.RewardXp).IsRequired();
+            builder.Property(x => x.RewardCoins).IsRequired();
+        }
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Storage/LocalObjectStorage.cs
+++ b/Tycoon.Backend.Infrastructure/Storage/LocalObjectStorage.cs
@@ -25,5 +25,14 @@ namespace Tycoon.Backend.Infrastructure.Storage
         }
 
         public string GetPublicUrl(string key) => $"/{key}";
+
+        public Task<Stream?> GetAsync(string key, CancellationToken ct = default)
+        {
+            var fullPath = Path.Combine(_root, key.Replace('/', Path.DirectorySeparatorChar));
+            if (!File.Exists(fullPath))
+                return Task.FromResult<Stream?>(null);
+
+            return Task.FromResult<Stream?>(File.OpenRead(fullPath));
+        }
     }
 }

--- a/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
+++ b/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
@@ -62,6 +62,27 @@ namespace Tycoon.Backend.Infrastructure.Storage
             return internalUrl;
         }
 
+        public async Task<Stream?> GetAsync(string key, CancellationToken ct = default)
+        {
+            await EnsureBucketExistsAsync(ct);
+            var ms = new MemoryStream();
+            try
+            {
+                var args = new GetObjectArgs()
+                    .WithBucket(_options.Bucket)
+                    .WithObject(key)
+                    .WithCallbackStream(async stream => await stream.CopyToAsync(ms, ct));
+                await _client.GetObjectAsync(args, ct);
+                ms.Position = 0;
+                return ms;
+            }
+            catch (Exception ex) when (ex.Message.Contains("NoSuchKey") || ex.Message.Contains("Not Found") || ex.GetType().Name.Contains("ObjectNotFound"))
+            {
+                await ms.DisposeAsync();
+                return null;
+            }
+        }
+
         public async Task<string> GetPresignedGetUrlAsync(string key, TimeSpan expiry, CancellationToken ct = default)
         {
             await EnsureBucketExistsAsync(ct);

--- a/Tycoon.MigrationService/MigrationWorker.cs
+++ b/Tycoon.MigrationService/MigrationWorker.cs
@@ -144,6 +144,19 @@ public sealed class MigrationWorker : BackgroundService
                 await seeder.SeedAsync(db, stoppingToken);
                 _log.Information("Seeding completed successfully");
 
+                _log.Information("Seeding catalog data from MinIO (idempotent)…");
+                try
+                {
+                    var minioSeeder = scope.ServiceProvider.GetRequiredService<MinioSeeder>();
+                    await minioSeeder.SeedAsync(db, stoppingToken);
+                    _log.Information("MinIO catalog seeding completed");
+                }
+                catch (Exception ex)
+                {
+                    _log.Warning(ex, "MinIO catalog seeding failed (non-fatal). " +
+                        "Ensure MinIO is running and seed files exist at seeds/*.json.");
+                }
+
                 _log.Information("Resetting Daily/Weekly mission claims (idempotent)…");
                 var reset = scope.ServiceProvider.GetRequiredService<MissionResetService>();
                 await reset.ResetAsync(db, stoppingToken);

--- a/Tycoon.MigrationService/Program.cs
+++ b/Tycoon.MigrationService/Program.cs
@@ -42,6 +42,7 @@ try
             // Seeder + reset services
             services.AddTransient<AppSeeder>();
             services.AddTransient<MissionResetService>();
+            services.AddTransient<MinioSeeder>();
 
             // Worker
             services.AddHostedService<MigrationWorker>();

--- a/Tycoon.MigrationService/Seeding/MinioSeeder.cs
+++ b/Tycoon.MigrationService/Seeding/MinioSeeder.cs
@@ -1,0 +1,285 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Serilog;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Infrastructure.Persistence;
+using Tycoon.MigrationService.Seeding.SeedModels;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.MigrationService.Seeding;
+
+/// <summary>
+/// Reads JSON seed files from MinIO object storage and upserts catalog data into the database.
+/// Each seed key is checked for existence; if the MinIO object is not found the step is skipped gracefully.
+/// </summary>
+public sealed class MinioSeeder
+{
+    private readonly IObjectStorage _storage;
+    private readonly Serilog.ILogger _log;
+
+    private static readonly JsonSerializerOptions JsonOpts = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private const string StoreItemsKey   = "seeds/store-items.json";
+    private const string SkillNodesKey   = "seeds/skill-nodes.json";
+    private const string SeasonRewardsKey = "seeds/season-rewards.json";
+    private const string QuestionsKey    = "seeds/questions.json";
+
+    public MinioSeeder(IObjectStorage storage)
+    {
+        _storage = storage;
+        _log = Log.ForContext<MinioSeeder>();
+    }
+
+    public async Task SeedAsync(AppDb db, CancellationToken ct)
+    {
+        var strategy = db.Database.CreateExecutionStrategy();
+        await strategy.ExecuteAsync(async () =>
+        {
+            await SeedStoreItemsAsync(db, ct);
+            await SeedSkillNodesAsync(db, ct);
+            await SeedSeasonRewardsAsync(db, ct);
+            await SeedQuestionsAsync(db, ct);
+        });
+    }
+
+    // ── Store Items ──────────────────────────────────────────────────────────
+
+    private async Task SeedStoreItemsAsync(AppDb db, CancellationToken ct)
+    {
+        var models = await ReadJsonAsync<List<StoreItemSeedModel>>(StoreItemsKey, ct);
+        if (models is null) return;
+
+        _log.Information("MinioSeeder: seeding {Count} store items…", models.Count);
+        var seeded = 0;
+        var updated = 0;
+
+        foreach (var m in models)
+        {
+            var existing = await db.StoreItems.FirstOrDefaultAsync(x => x.Sku == m.Sku, ct);
+            if (existing is null)
+            {
+                db.StoreItems.Add(new StoreItem
+                {
+                    Sku          = m.Sku,
+                    Name         = m.Name,
+                    Description  = m.Description ?? string.Empty,
+                    ItemType     = m.ItemType,
+                    PriceCoins   = m.PriceCoins,
+                    PriceDiamonds = m.PriceDiamonds,
+                    GrantQuantity = m.GrantQuantity > 0 ? m.GrantQuantity : 1,
+                    MaxPerPlayer = m.MaxPerPlayer,
+                    IsActive     = m.IsActive,
+                    SortOrder    = m.SortOrder,
+                    MediaKey     = m.MediaKey,
+                    ThumbnailUrl = m.ThumbnailUrl,
+                    IsFeatured   = m.IsFeatured,
+                    Version      = m.Version,
+                    UpdatedAtUtc = DateTimeOffset.UtcNow,
+                });
+                seeded++;
+            }
+            else
+            {
+                existing.Name         = m.Name;
+                existing.Description  = m.Description ?? string.Empty;
+                existing.ItemType     = m.ItemType;
+                existing.PriceCoins   = m.PriceCoins;
+                existing.PriceDiamonds = m.PriceDiamonds;
+                existing.GrantQuantity = m.GrantQuantity > 0 ? m.GrantQuantity : 1;
+                existing.MaxPerPlayer = m.MaxPerPlayer;
+                existing.IsActive     = m.IsActive;
+                existing.SortOrder    = m.SortOrder;
+                existing.MediaKey     = m.MediaKey;
+                existing.ThumbnailUrl = m.ThumbnailUrl;
+                existing.IsFeatured   = m.IsFeatured;
+                existing.Version      = m.Version;
+                existing.UpdatedAtUtc = DateTimeOffset.UtcNow;
+                updated++;
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        _log.Information("MinioSeeder: store items — {Seeded} created, {Updated} updated.", seeded, updated);
+    }
+
+    // ── Skill Nodes ──────────────────────────────────────────────────────────
+
+    private async Task SeedSkillNodesAsync(AppDb db, CancellationToken ct)
+    {
+        var models = await ReadJsonAsync<List<SkillNodeSeedModel>>(SkillNodesKey, ct);
+        if (models is null) return;
+
+        _log.Information("MinioSeeder: seeding {Count} skill nodes…", models.Count);
+        var seeded = 0;
+        var updated = 0;
+
+        foreach (var m in models)
+        {
+            if (!Enum.TryParse<SkillBranch>(m.Branch, ignoreCase: true, out var branch))
+            {
+                _log.Warning("MinioSeeder: unknown SkillBranch '{Branch}' for node '{Key}' — skipping.", m.Branch, m.Key);
+                continue;
+            }
+
+            var prereqJson  = JsonSerializer.Serialize(m.PrereqKeys  ?? Array.Empty<string>(),                   JsonOpts);
+            var costsJson   = JsonSerializer.Serialize(MapCosts(m.Costs),                                         JsonOpts);
+            var effectsJson = JsonSerializer.Serialize(m.Effects ?? new Dictionary<string, double>(),             JsonOpts);
+
+            var existing = await db.SkillNodes.FirstOrDefaultAsync(x => x.Key == m.Key, ct);
+            if (existing is null)
+            {
+                db.SkillNodes.Add(new SkillNode(m.Key, branch, m.Tier, m.Title, m.Description,
+                    prereqJson, costsJson, effectsJson));
+                seeded++;
+            }
+            else
+            {
+                // SkillNode uses private setters — update via reflection (same pattern as SkillTreeService)
+                SetPrivate(existing, nameof(SkillNode.Branch),        branch);
+                SetPrivate(existing, nameof(SkillNode.Tier),          m.Tier);
+                SetPrivate(existing, nameof(SkillNode.Title),         m.Title);
+                SetPrivate(existing, nameof(SkillNode.Description),   m.Description);
+                SetPrivate(existing, nameof(SkillNode.PrereqKeysJson), prereqJson);
+                SetPrivate(existing, nameof(SkillNode.CostsJson),     costsJson);
+                SetPrivate(existing, nameof(SkillNode.EffectsJson),   effectsJson);
+                existing.Touch();
+                updated++;
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        _log.Information("MinioSeeder: skill nodes — {Seeded} created, {Updated} updated.", seeded, updated);
+    }
+
+    // ── Season Reward Rules ──────────────────────────────────────────────────
+
+    private async Task SeedSeasonRewardsAsync(AppDb db, CancellationToken ct)
+    {
+        var models = await ReadJsonAsync<List<SeasonRewardSeedModel>>(SeasonRewardsKey, ct);
+        if (models is null) return;
+
+        _log.Information("MinioSeeder: seeding {Count} season reward rules…", models.Count);
+        var seeded = 0;
+
+        foreach (var m in models)
+        {
+            var exists = await db.SeasonRewardRules
+                .AsNoTracking()
+                .AnyAsync(x => x.Tier == m.Tier && x.MaxTierRank == m.MaxTierRank, ct);
+
+            if (!exists)
+            {
+                db.SeasonRewardRules.Add(new SeasonRewardRule(m.Tier, m.MaxTierRank, m.RewardXp, m.RewardCoins));
+                seeded++;
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        _log.Information("MinioSeeder: season reward rules — {Seeded} created (existing rows skipped).", seeded);
+    }
+
+    // ── Questions ────────────────────────────────────────────────────────────
+
+    private async Task SeedQuestionsAsync(AppDb db, CancellationToken ct)
+    {
+        var models = await ReadJsonAsync<List<QuestionSeedModel>>(QuestionsKey, ct);
+        if (models is null) return;
+
+        _log.Information("MinioSeeder: seeding {Count} questions…", models.Count);
+        var seeded = 0;
+        var updated = 0;
+
+        foreach (var m in models)
+        {
+            if (!Enum.TryParse<QuestionDifficulty>(m.Difficulty, ignoreCase: true, out var difficulty))
+            {
+                _log.Warning("MinioSeeder: unknown difficulty '{Difficulty}' for question — skipping.", m.Difficulty);
+                continue;
+            }
+
+            var normalizedText = m.Text.Trim();
+            var existing = await db.Questions
+                .Include(q => q.Options)
+                .Include(q => q.Tags)
+                .FirstOrDefaultAsync(q => q.Text == normalizedText, ct);
+
+            if (existing is null)
+            {
+                var q = new Question(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
+
+                if (m.Options.Length > 0)
+                    q.ReplaceOptions(m.Options.Select(o => new QuestionOption(q.Id, o.OptionId, o.Text)));
+
+                if (m.Tags.Length > 0)
+                    q.ReplaceTags(m.Tags);
+
+                if (!string.IsNullOrWhiteSpace(m.Status))
+                    q.SetStatus(m.Status);
+
+                db.Questions.Add(q);
+                seeded++;
+            }
+            else
+            {
+                existing.Update(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
+
+                if (m.Options.Length > 0)
+                    existing.ReplaceOptions(m.Options.Select(o => new QuestionOption(existing.Id, o.OptionId, o.Text)));
+
+                if (m.Tags.Length > 0)
+                    existing.ReplaceTags(m.Tags);
+
+                if (!string.IsNullOrWhiteSpace(m.Status))
+                    existing.SetStatus(m.Status);
+
+                updated++;
+            }
+        }
+
+        await db.SaveChangesAsync(ct);
+        _log.Information("MinioSeeder: questions — {Seeded} created, {Updated} updated.", seeded, updated);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<T?> ReadJsonAsync<T>(string key, CancellationToken ct)
+    {
+        await using var stream = await _storage.GetAsync(key, ct);
+        if (stream is null)
+        {
+            _log.Information("MinioSeeder: seed file '{Key}' not found in storage — skipping.", key);
+            return default;
+        }
+
+        try
+        {
+            return await JsonSerializer.DeserializeAsync<T>(stream, JsonOpts, ct);
+        }
+        catch (Exception ex)
+        {
+            _log.Warning(ex, "MinioSeeder: failed to deserialize '{Key}' — skipping.", key);
+            return default;
+        }
+    }
+
+    private static IReadOnlyList<SkillCostDto> MapCosts(SkillCostSeedModel[]? models)
+    {
+        if (models is null or { Length: 0 })
+            return Array.Empty<SkillCostDto>();
+
+        return models
+            .Select(c => new SkillCostDto(
+                Enum.TryParse<CurrencyType>(c.Currency, ignoreCase: true, out var ct) ? ct : CurrencyType.Coins,
+                c.Amount))
+            .ToArray();
+    }
+
+    private static void SetPrivate(object target, string propertyName, object? value) =>
+        target.GetType()
+              .GetProperty(propertyName)!
+              .SetValue(target, value);
+}

--- a/Tycoon.MigrationService/Seeding/SeedModels/QuestionSeedModel.cs
+++ b/Tycoon.MigrationService/Seeding/SeedModels/QuestionSeedModel.cs
@@ -1,0 +1,17 @@
+namespace Tycoon.MigrationService.Seeding.SeedModels;
+
+public sealed record QuestionSeedModel(
+    string Text,
+    string Category,
+    string Difficulty,
+    string CorrectOptionId,
+    string? MediaKey,
+    QuestionOptionSeedModel[] Options,
+    string[] Tags,
+    string Status
+);
+
+public sealed record QuestionOptionSeedModel(
+    string OptionId,
+    string Text
+);

--- a/Tycoon.MigrationService/Seeding/SeedModels/SeasonRewardSeedModel.cs
+++ b/Tycoon.MigrationService/Seeding/SeedModels/SeasonRewardSeedModel.cs
@@ -1,0 +1,8 @@
+namespace Tycoon.MigrationService.Seeding.SeedModels;
+
+public sealed record SeasonRewardSeedModel(
+    int Tier,
+    int MaxTierRank,
+    int RewardXp,
+    int RewardCoins
+);

--- a/Tycoon.MigrationService/Seeding/SeedModels/SkillNodeSeedModel.cs
+++ b/Tycoon.MigrationService/Seeding/SeedModels/SkillNodeSeedModel.cs
@@ -1,0 +1,17 @@
+namespace Tycoon.MigrationService.Seeding.SeedModels;
+
+public sealed record SkillNodeSeedModel(
+    string Key,
+    string Branch,
+    int Tier,
+    string Title,
+    string Description,
+    string[] PrereqKeys,
+    SkillCostSeedModel[] Costs,
+    Dictionary<string, double> Effects
+);
+
+public sealed record SkillCostSeedModel(
+    string Currency,
+    int Amount
+);

--- a/Tycoon.MigrationService/Seeding/SeedModels/StoreItemSeedModel.cs
+++ b/Tycoon.MigrationService/Seeding/SeedModels/StoreItemSeedModel.cs
@@ -1,0 +1,18 @@
+namespace Tycoon.MigrationService.Seeding.SeedModels;
+
+public sealed record StoreItemSeedModel(
+    string Sku,
+    string Name,
+    string? Description,
+    string ItemType,
+    int PriceCoins,
+    int PriceDiamonds,
+    int GrantQuantity,
+    int MaxPerPlayer,
+    bool IsActive,
+    int SortOrder,
+    string? MediaKey,
+    string? ThumbnailUrl,
+    bool IsFeatured,
+    string? Version
+);

--- a/Tycoon.MigrationService/Tycoon.MigrationService.csproj
+++ b/Tycoon.MigrationService/Tycoon.MigrationService.csproj
@@ -29,6 +29,7 @@
     <ProjectReference Include="..\Tycoon.Backend.Migrations\Tycoon.Backend.Migrations.csproj" />
     <ProjectReference Include="..\Tycoon.ServiceDefaults\Tycoon.ServiceDefaults.csproj" />
     <ProjectReference Include="..\Tycoon.Shared\Tycoon.Shared.csproj" />
+    <ProjectReference Include="..\Tycoon.Shared.Contracts\Tycoon.Shared.Contracts.csproj" />
   </ItemGroup>
 
 </Project>

--- a/docs/minio-seed-data-format.md
+++ b/docs/minio-seed-data-format.md
@@ -1,0 +1,204 @@
+# MinIO Seed Data Format
+
+The `MigrationService` reads JSON seed files from MinIO at startup and upserts them into the database idempotently. Upload these files to your MinIO bucket before running migrations.
+
+## MinIO Object Keys
+
+| Entity | Key |
+|--------|-----|
+| Store Items | `seeds/store-items.json` |
+| Skill Nodes | `seeds/skill-nodes.json` |
+| Season Reward Rules | `seeds/season-rewards.json` |
+| Questions | `seeds/questions.json` |
+
+If a key does not exist the step is silently skipped — you only need to upload the files you want to seed.
+
+---
+
+## `seeds/store-items.json`
+
+Array of store catalog items. Upserted by `sku` (create or update).
+
+```json
+[
+  {
+    "sku": "avatar:cartoon-hero:v1",
+    "name": "Cartoon Hero",
+    "description": "A bold cartoon-style 3D avatar.",
+    "itemType": "avatar",
+    "priceCoins": 500,
+    "priceDiamonds": 0,
+    "grantQuantity": 1,
+    "maxPerPlayer": 1,
+    "isActive": true,
+    "sortOrder": 10,
+    "mediaKey": "avatars/cartoon-hero-v1",
+    "thumbnailUrl": "https://cdn.example.com/avatars/cartoon-hero-thumb.png",
+    "isFeatured": true,
+    "version": "1.0.0"
+  },
+  {
+    "sku": "powerup:skip",
+    "name": "Question Skip",
+    "description": "Skip any question once.",
+    "itemType": "powerup",
+    "priceCoins": 50,
+    "priceDiamonds": 0,
+    "grantQuantity": 1,
+    "maxPerPlayer": 0,
+    "isActive": true,
+    "sortOrder": 1,
+    "mediaKey": null,
+    "thumbnailUrl": null,
+    "isFeatured": false,
+    "version": null
+  }
+]
+```
+
+**Field notes:**
+- `sku` — stable unique identifier; used as the upsert key
+- `itemType` — routing type: `"avatar"`, `"powerup"`, `"cosmetic"`, etc.
+- `grantQuantity` — quantity granted per purchase; defaults to 1 if 0 or omitted
+- `maxPerPlayer` — 0 = unlimited purchases
+- `mediaKey` — object storage key prefix (`.zip` appended for avatar archives)
+
+---
+
+## `seeds/skill-nodes.json`
+
+Array of skill tree nodes. Upserted by `key` (create or update).
+
+```json
+[
+  {
+    "key": "knowledge:recall-boost:1",
+    "branch": "Knowledge",
+    "tier": 1,
+    "title": "Recall Boost I",
+    "description": "Increase XP gained from correct answers by 5%.",
+    "prereqKeys": [],
+    "costs": [
+      { "currency": "Coins", "amount": 100 }
+    ],
+    "effects": {
+      "xp_multiplier": 1.05
+    }
+  },
+  {
+    "key": "strategy:time-extend:1",
+    "branch": "Strategy",
+    "tier": 1,
+    "title": "Time Extend I",
+    "description": "Add 2 seconds to your answer timer.",
+    "prereqKeys": [],
+    "costs": [
+      { "currency": "Coins", "amount": 150 }
+    ],
+    "effects": {
+      "timer_bonus_seconds": 2
+    }
+  }
+]
+```
+
+**Field notes:**
+- `key` — stable unique node key; used as the upsert key
+- `branch` — `"Knowledge"`, `"Strategy"`, or `"Powerups"` (case-insensitive)
+- `costs[].currency` — `"Coins"` or `"Diamonds"` (case-insensitive)
+- `effects` — arbitrary key/value map consumed by the gameplay engine
+
+---
+
+## `seeds/season-rewards.json`
+
+Array of reward rules for each season tier rank. Created only if the `(tier, maxTierRank)` pair does not already exist.
+
+```json
+[
+  { "tier": 1, "maxTierRank": 100, "rewardXp": 0,    "rewardCoins": 25  },
+  { "tier": 2, "maxTierRank": 50,  "rewardXp": 0,    "rewardCoins": 75  },
+  { "tier": 3, "maxTierRank": 25,  "rewardXp": 50,   "rewardCoins": 150 },
+  { "tier": 4, "maxTierRank": 10,  "rewardXp": 100,  "rewardCoins": 300 },
+  { "tier": 5, "maxTierRank": 1,   "rewardXp": 250,  "rewardCoins": 750 }
+]
+```
+
+**Field notes:**
+- `(tier, maxTierRank)` — composite upsert key; existing rows are not updated
+- `tier` — matches the Tier ordinal (1=Bronze … 5=Diamond)
+- `maxTierRank` — top-N player cutoff for this reward bracket
+
+> **Migration required:** `SeasonRewardRule` is a new table (`season_reward_rules`). Run `dotnet ef migrations add AddSeasonRewardRules` before seeding.
+
+---
+
+## `seeds/questions.json`
+
+Array of quiz questions. Upserted by `text` (create or update). Each question must have at least one option; the `correctOptionId` must match one of the `options[].optionId` values.
+
+```json
+[
+  {
+    "text": "What is the capital of France?",
+    "category": "Geography",
+    "difficulty": "Easy",
+    "correctOptionId": "A",
+    "mediaKey": null,
+    "status": "Approved",
+    "options": [
+      { "optionId": "A", "text": "Paris" },
+      { "optionId": "B", "text": "London" },
+      { "optionId": "C", "text": "Berlin" },
+      { "optionId": "D", "text": "Madrid" }
+    ],
+    "tags": ["europe", "capitals"]
+  },
+  {
+    "text": "Which element has atomic number 79?",
+    "category": "Science",
+    "difficulty": "Medium",
+    "correctOptionId": "C",
+    "mediaKey": null,
+    "status": "Approved",
+    "options": [
+      { "optionId": "A", "text": "Silver" },
+      { "optionId": "B", "text": "Platinum" },
+      { "optionId": "C", "text": "Gold" },
+      { "optionId": "D", "text": "Copper" }
+    ],
+    "tags": ["chemistry", "elements"]
+  }
+]
+```
+
+**Field notes:**
+- `text` — unique question text used as the upsert key (trimmed)
+- `difficulty` — `"Easy"`, `"Medium"`, or `"Hard"` (case-insensitive)
+- `status` — `"Draft"`, `"Approved"`, `"Rejected"`, or `"Archived"`
+- `options` — replaced entirely on update; `optionId` is a stable string like `"A"`, `"B"`, etc.
+- `tags` — replaced entirely on update
+
+---
+
+## Uploading Seed Files to MinIO
+
+Using the MinIO CLI (`mc`):
+
+```bash
+mc alias set local http://localhost:9000 minioadmin minioadmin
+mc cp seeds/store-items.json   local/tycoon/seeds/store-items.json
+mc cp seeds/skill-nodes.json   local/tycoon/seeds/skill-nodes.json
+mc cp seeds/season-rewards.json local/tycoon/seeds/season-rewards.json
+mc cp seeds/questions.json     local/tycoon/seeds/questions.json
+```
+
+Replace `tycoon` with your configured bucket name (`Minio:Bucket` in `appsettings`).
+
+Then run the migration service:
+
+```bash
+dotnet run --project Tycoon.MigrationService
+```
+
+The seeder runs at every startup but is fully idempotent — re-uploading an updated file and restarting the service will apply the delta.


### PR DESCRIPTION
…wardRules, and Questions

- Add IObjectStorage.GetAsync + implement in MinioObjectStorage (GetObjectArgs) and LocalObjectStorage (disk read)
- Add SeasonRewardRule DbSet to IAppDb/AppDb + SeasonRewardRuleConfiguration (requires migration AddSeasonRewardRules)
- Create MinioSeeder reading seeds/*.json from object storage; fully idempotent upsert per entity
- Register MinioSeeder in MigrationService with non-fatal try/catch so missing MinIO does not block startup
- Add Tycoon.Shared.Contracts project reference to MigrationService
- Document seed file JSON schemas in docs/minio-seed-data-format.md

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2