### PR TITLE
Simplify MinioSeeder: eliminate N+1 queries, parallel reads, dedup he…

### DIFF
--- a/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
+++ b/Tycoon.Backend.Infrastructure/Storage/MinioObjectStorage.cs
@@ -8,6 +8,7 @@ namespace Tycoon.Backend.Infrastructure.Storage
     {
         private readonly IMinioClient _client;
         private readonly MinioOptions _options;
+        private bool _bucketEnsured;
 
         public MinioObjectStorage(IMinioClient client, MinioOptions options)
         {
@@ -76,7 +77,7 @@ namespace Tycoon.Backend.Infrastructure.Storage
                 ms.Position = 0;
                 return ms;
             }
-            catch (Exception ex) when (ex.Message.Contains("NoSuchKey") || ex.Message.Contains("Not Found") || ex.GetType().Name.Contains("ObjectNotFound"))
+            catch (Exception ex) when (IsObjectNotFoundError(ex))
             {
                 await ms.DisposeAsync();
                 return null;
@@ -108,12 +109,22 @@ namespace Tycoon.Backend.Infrastructure.Storage
 
         private async Task EnsureBucketExistsAsync(CancellationToken ct)
         {
+            if (_bucketEnsured) return;
+
             var exists = await _client.BucketExistsAsync(
                 new BucketExistsArgs().WithBucket(_options.Bucket), ct);
 
             if (!exists)
                 await _client.MakeBucketAsync(
                     new MakeBucketArgs().WithBucket(_options.Bucket), ct);
+
+            _bucketEnsured = true;
         }
+
+        // Minio SDK v6 throws ObjectNotFoundException (S3 NoSuchKey) for missing objects.
+        // Guard against the specific S3 error code as a stable secondary check.
+        private static bool IsObjectNotFoundError(Exception ex) =>
+            ex.GetType().Name is "ObjectNotFoundException" or "BucketNotFoundException" ||
+            ex.Message.Contains("NoSuchKey", StringComparison.OrdinalIgnoreCase);
     }
 }

--- a/Tycoon.MigrationService/Seeding/MinioSeeder.cs
+++ b/Tycoon.MigrationService/Seeding/MinioSeeder.cs
@@ -9,24 +9,17 @@ using Tycoon.Shared.Contracts.Dtos;
 
 namespace Tycoon.MigrationService.Seeding;
 
-/// <summary>
-/// Reads JSON seed files from MinIO object storage and upserts catalog data into the database.
-/// Each seed key is checked for existence; if the MinIO object is not found the step is skipped gracefully.
-/// </summary>
 public sealed class MinioSeeder
 {
     private readonly IObjectStorage _storage;
     private readonly Serilog.ILogger _log;
 
-    private static readonly JsonSerializerOptions JsonOpts = new()
-    {
-        PropertyNameCaseInsensitive = true
-    };
+    private static readonly JsonSerializerOptions JsonOpts = new(JsonSerializerDefaults.Web);
 
-    private const string StoreItemsKey   = "seeds/store-items.json";
-    private const string SkillNodesKey   = "seeds/skill-nodes.json";
+    private const string StoreItemsKey    = "seeds/store-items.json";
+    private const string SkillNodesKey    = "seeds/skill-nodes.json";
     private const string SeasonRewardsKey = "seeds/season-rewards.json";
-    private const string QuestionsKey    = "seeds/questions.json";
+    private const string QuestionsKey     = "seeds/questions.json";
 
     public MinioSeeder(IObjectStorage storage)
     {
@@ -36,69 +29,52 @@ public sealed class MinioSeeder
 
     public async Task SeedAsync(AppDb db, CancellationToken ct)
     {
+        // Read all seed files concurrently before touching the DB.
+        var storeTask    = ReadJsonAsync<List<StoreItemSeedModel>>(StoreItemsKey, ct);
+        var skillTask    = ReadJsonAsync<List<SkillNodeSeedModel>>(SkillNodesKey, ct);
+        var seasonTask   = ReadJsonAsync<List<SeasonRewardSeedModel>>(SeasonRewardsKey, ct);
+        var questionTask = ReadJsonAsync<List<QuestionSeedModel>>(QuestionsKey, ct);
+        await Task.WhenAll(storeTask, skillTask, seasonTask, questionTask);
+
         var strategy = db.Database.CreateExecutionStrategy();
         await strategy.ExecuteAsync(async () =>
         {
-            await SeedStoreItemsAsync(db, ct);
-            await SeedSkillNodesAsync(db, ct);
-            await SeedSeasonRewardsAsync(db, ct);
-            await SeedQuestionsAsync(db, ct);
+            await SeedStoreItemsAsync(db, await storeTask, ct);
+            await SeedSkillNodesAsync(db, await skillTask, ct);
+            await SeedSeasonRewardsAsync(db, await seasonTask, ct);
+            await SeedQuestionsAsync(db, await questionTask, ct);
         });
     }
 
     // ── Store Items ──────────────────────────────────────────────────────────
 
-    private async Task SeedStoreItemsAsync(AppDb db, CancellationToken ct)
+    private async Task SeedStoreItemsAsync(AppDb db, List<StoreItemSeedModel>? models, CancellationToken ct)
     {
-        var models = await ReadJsonAsync<List<StoreItemSeedModel>>(StoreItemsKey, ct);
         if (models is null) return;
 
         _log.Information("MinioSeeder: seeding {Count} store items…", models.Count);
+
+        var seedSkus = models.ConvertAll(m => m.Sku);
+        var existingMap = await db.StoreItems
+            .Where(x => seedSkus.Contains(x.Sku))
+            .ToDictionaryAsync(x => x.Sku, ct);
+
         var seeded = 0;
         var updated = 0;
 
         foreach (var m in models)
         {
-            var existing = await db.StoreItems.FirstOrDefaultAsync(x => x.Sku == m.Sku, ct);
-            if (existing is null)
+            if (existingMap.TryGetValue(m.Sku, out var existing))
             {
-                db.StoreItems.Add(new StoreItem
-                {
-                    Sku          = m.Sku,
-                    Name         = m.Name,
-                    Description  = m.Description ?? string.Empty,
-                    ItemType     = m.ItemType,
-                    PriceCoins   = m.PriceCoins,
-                    PriceDiamonds = m.PriceDiamonds,
-                    GrantQuantity = m.GrantQuantity > 0 ? m.GrantQuantity : 1,
-                    MaxPerPlayer = m.MaxPerPlayer,
-                    IsActive     = m.IsActive,
-                    SortOrder    = m.SortOrder,
-                    MediaKey     = m.MediaKey,
-                    ThumbnailUrl = m.ThumbnailUrl,
-                    IsFeatured   = m.IsFeatured,
-                    Version      = m.Version,
-                    UpdatedAtUtc = DateTimeOffset.UtcNow,
-                });
-                seeded++;
+                ApplyStoreItemFields(existing, m);
+                updated++;
             }
             else
             {
-                existing.Name         = m.Name;
-                existing.Description  = m.Description ?? string.Empty;
-                existing.ItemType     = m.ItemType;
-                existing.PriceCoins   = m.PriceCoins;
-                existing.PriceDiamonds = m.PriceDiamonds;
-                existing.GrantQuantity = m.GrantQuantity > 0 ? m.GrantQuantity : 1;
-                existing.MaxPerPlayer = m.MaxPerPlayer;
-                existing.IsActive     = m.IsActive;
-                existing.SortOrder    = m.SortOrder;
-                existing.MediaKey     = m.MediaKey;
-                existing.ThumbnailUrl = m.ThumbnailUrl;
-                existing.IsFeatured   = m.IsFeatured;
-                existing.Version      = m.Version;
-                existing.UpdatedAtUtc = DateTimeOffset.UtcNow;
-                updated++;
+                var item = new StoreItem { Sku = m.Sku };
+                ApplyStoreItemFields(item, m);
+                db.StoreItems.Add(item);
+                seeded++;
             }
         }
 
@@ -106,14 +82,37 @@ public sealed class MinioSeeder
         _log.Information("MinioSeeder: store items — {Seeded} created, {Updated} updated.", seeded, updated);
     }
 
+    private static void ApplyStoreItemFields(StoreItem item, StoreItemSeedModel m)
+    {
+        item.Name          = m.Name;
+        item.Description   = m.Description ?? string.Empty;
+        item.ItemType      = m.ItemType;
+        item.PriceCoins    = m.PriceCoins;
+        item.PriceDiamonds = m.PriceDiamonds;
+        item.GrantQuantity = m.GrantQuantity > 0 ? m.GrantQuantity : 1;
+        item.MaxPerPlayer  = m.MaxPerPlayer;
+        item.IsActive      = m.IsActive;
+        item.SortOrder     = m.SortOrder;
+        item.MediaKey      = m.MediaKey;
+        item.ThumbnailUrl  = m.ThumbnailUrl;
+        item.IsFeatured    = m.IsFeatured;
+        item.Version       = m.Version;
+        item.UpdatedAtUtc  = DateTimeOffset.UtcNow;
+    }
+
     // ── Skill Nodes ──────────────────────────────────────────────────────────
 
-    private async Task SeedSkillNodesAsync(AppDb db, CancellationToken ct)
+    private async Task SeedSkillNodesAsync(AppDb db, List<SkillNodeSeedModel>? models, CancellationToken ct)
     {
-        var models = await ReadJsonAsync<List<SkillNodeSeedModel>>(SkillNodesKey, ct);
         if (models is null) return;
 
         _log.Information("MinioSeeder: seeding {Count} skill nodes…", models.Count);
+
+        var seedKeys = models.ConvertAll(m => m.Key);
+        var existingMap = await db.SkillNodes
+            .Where(x => seedKeys.Contains(x.Key))
+            .ToDictionaryAsync(x => x.Key, ct);
+
         var seeded = 0;
         var updated = 0;
 
@@ -125,29 +124,28 @@ public sealed class MinioSeeder
                 continue;
             }
 
-            var prereqJson  = JsonSerializer.Serialize(m.PrereqKeys  ?? Array.Empty<string>(),                   JsonOpts);
-            var costsJson   = JsonSerializer.Serialize(MapCosts(m.Costs),                                         JsonOpts);
-            var effectsJson = JsonSerializer.Serialize(m.Effects ?? new Dictionary<string, double>(),             JsonOpts);
+            var prereqJson  = JsonSerializer.Serialize(m.PrereqKeys  ?? Array.Empty<string>(),             JsonOpts);
+            var costsJson   = JsonSerializer.Serialize(MapCosts(m.Costs),                                   JsonOpts);
+            var effectsJson = JsonSerializer.Serialize(m.Effects ?? new Dictionary<string, double>(),       JsonOpts);
 
-            var existing = await db.SkillNodes.FirstOrDefaultAsync(x => x.Key == m.Key, ct);
-            if (existing is null)
+            if (existingMap.TryGetValue(m.Key, out var existing))
+            {
+                // SkillNode uses private setters — reflection mirrors SkillTreeService.UpsertNodesAsync
+                SetPrivate(existing, nameof(SkillNode.Branch),         branch);
+                SetPrivate(existing, nameof(SkillNode.Tier),           m.Tier);
+                SetPrivate(existing, nameof(SkillNode.Title),          m.Title);
+                SetPrivate(existing, nameof(SkillNode.Description),    m.Description);
+                SetPrivate(existing, nameof(SkillNode.PrereqKeysJson), prereqJson);
+                SetPrivate(existing, nameof(SkillNode.CostsJson),      costsJson);
+                SetPrivate(existing, nameof(SkillNode.EffectsJson),    effectsJson);
+                existing.Touch();
+                updated++;
+            }
+            else
             {
                 db.SkillNodes.Add(new SkillNode(m.Key, branch, m.Tier, m.Title, m.Description,
                     prereqJson, costsJson, effectsJson));
                 seeded++;
-            }
-            else
-            {
-                // SkillNode uses private setters — update via reflection (same pattern as SkillTreeService)
-                SetPrivate(existing, nameof(SkillNode.Branch),        branch);
-                SetPrivate(existing, nameof(SkillNode.Tier),          m.Tier);
-                SetPrivate(existing, nameof(SkillNode.Title),         m.Title);
-                SetPrivate(existing, nameof(SkillNode.Description),   m.Description);
-                SetPrivate(existing, nameof(SkillNode.PrereqKeysJson), prereqJson);
-                SetPrivate(existing, nameof(SkillNode.CostsJson),     costsJson);
-                SetPrivate(existing, nameof(SkillNode.EffectsJson),   effectsJson);
-                existing.Touch();
-                updated++;
             }
         }
 
@@ -157,21 +155,23 @@ public sealed class MinioSeeder
 
     // ── Season Reward Rules ──────────────────────────────────────────────────
 
-    private async Task SeedSeasonRewardsAsync(AppDb db, CancellationToken ct)
+    private async Task SeedSeasonRewardsAsync(AppDb db, List<SeasonRewardSeedModel>? models, CancellationToken ct)
     {
-        var models = await ReadJsonAsync<List<SeasonRewardSeedModel>>(SeasonRewardsKey, ct);
         if (models is null) return;
 
         _log.Information("MinioSeeder: seeding {Count} season reward rules…", models.Count);
+
+        var existingPairs = await db.SeasonRewardRules
+            .AsNoTracking()
+            .Select(x => new { x.Tier, x.MaxTierRank })
+            .ToListAsync(ct);
+        var existingSet = existingPairs.Select(x => (x.Tier, x.MaxTierRank)).ToHashSet();
+
         var seeded = 0;
 
         foreach (var m in models)
         {
-            var exists = await db.SeasonRewardRules
-                .AsNoTracking()
-                .AnyAsync(x => x.Tier == m.Tier && x.MaxTierRank == m.MaxTierRank, ct);
-
-            if (!exists)
+            if (!existingSet.Contains((m.Tier, m.MaxTierRank)))
             {
                 db.SeasonRewardRules.Add(new SeasonRewardRule(m.Tier, m.MaxTierRank, m.RewardXp, m.RewardCoins));
                 seeded++;
@@ -184,12 +184,19 @@ public sealed class MinioSeeder
 
     // ── Questions ────────────────────────────────────────────────────────────
 
-    private async Task SeedQuestionsAsync(AppDb db, CancellationToken ct)
+    private async Task SeedQuestionsAsync(AppDb db, List<QuestionSeedModel>? models, CancellationToken ct)
     {
-        var models = await ReadJsonAsync<List<QuestionSeedModel>>(QuestionsKey, ct);
         if (models is null) return;
 
         _log.Information("MinioSeeder: seeding {Count} questions…", models.Count);
+
+        var seedTexts = models.ConvertAll(m => m.Text.Trim());
+        var existingMap = await db.Questions
+            .Where(q => seedTexts.Contains(q.Text))
+            .Include(q => q.Options)
+            .Include(q => q.Tags)
+            .ToDictionaryAsync(q => q.Text, ct);
+
         var seeded = 0;
         var updated = 0;
 
@@ -202,46 +209,36 @@ public sealed class MinioSeeder
             }
 
             var normalizedText = m.Text.Trim();
-            var existing = await db.Questions
-                .Include(q => q.Options)
-                .Include(q => q.Tags)
-                .FirstOrDefaultAsync(q => q.Text == normalizedText, ct);
 
-            if (existing is null)
+            if (existingMap.TryGetValue(normalizedText, out var existing))
             {
-                var q = new Question(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
-
-                if (m.Options.Length > 0)
-                    q.ReplaceOptions(m.Options.Select(o => new QuestionOption(q.Id, o.OptionId, o.Text)));
-
-                if (m.Tags.Length > 0)
-                    q.ReplaceTags(m.Tags);
-
-                if (!string.IsNullOrWhiteSpace(m.Status))
-                    q.SetStatus(m.Status);
-
-                db.Questions.Add(q);
-                seeded++;
+                existing.Update(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
+                ApplyQuestionRelations(existing, m);
+                updated++;
             }
             else
             {
-                existing.Update(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
-
-                if (m.Options.Length > 0)
-                    existing.ReplaceOptions(m.Options.Select(o => new QuestionOption(existing.Id, o.OptionId, o.Text)));
-
-                if (m.Tags.Length > 0)
-                    existing.ReplaceTags(m.Tags);
-
-                if (!string.IsNullOrWhiteSpace(m.Status))
-                    existing.SetStatus(m.Status);
-
-                updated++;
+                var q = new Question(normalizedText, m.Category, difficulty, m.CorrectOptionId, m.MediaKey);
+                ApplyQuestionRelations(q, m);
+                db.Questions.Add(q);
+                seeded++;
             }
         }
 
         await db.SaveChangesAsync(ct);
         _log.Information("MinioSeeder: questions — {Seeded} created, {Updated} updated.", seeded, updated);
+    }
+
+    private static void ApplyQuestionRelations(Question question, QuestionSeedModel m)
+    {
+        if (m.Options.Length > 0)
+            question.ReplaceOptions(m.Options.Select(o => new QuestionOption(question.Id, o.OptionId, o.Text)));
+
+        if (m.Tags.Length > 0)
+            question.ReplaceTags(m.Tags);
+
+        if (!string.IsNullOrWhiteSpace(m.Status))
+            question.SetStatus(m.Status);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────
@@ -273,13 +270,13 @@ public sealed class MinioSeeder
 
         return models
             .Select(c => new SkillCostDto(
-                Enum.TryParse<CurrencyType>(c.Currency, ignoreCase: true, out var ct) ? ct : CurrencyType.Coins,
+                Enum.TryParse<CurrencyType>(c.Currency, ignoreCase: true, out var currency)
+                    ? currency
+                    : CurrencyType.Coins,
                 c.Amount))
             .ToArray();
     }
 
     private static void SetPrivate(object target, string propertyName, object? value) =>
-        target.GetType()
-              .GetProperty(propertyName)!
-              .SetValue(target, value);
+        target.GetType().GetProperty(propertyName)!.SetValue(target, value);
 }


### PR DESCRIPTION
…lpers

- Load existing records in bulk (1 query per entity type) instead of N queries per seed record
- Read all 4 MinIO JSON files concurrently with Task.WhenAll before processing
- Extract ApplyStoreItemFields() to eliminate create/update copy-paste block (13 fields)
- Extract ApplyQuestionRelations() to eliminate Options/Tags/Status duplication in create and update branches
- Pre-load questions with Include(Options,Tags) in a single filtered query instead of per-record eager loads
- Replace stringly-typed MinIO exception catch (message.Contains) with IsObjectNotFoundError() using type name + S3 NoSuchKey code
- Cache bucket existence check in _bucketEnsured flag so EnsureBucketExistsAsync is a no-op after first call
- Use JsonSerializerDefaults.Web for consistency with rest of codebase

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2