### PR TITLE
Update docs: store/admin handoff, remaining tasks, changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,71 @@ All notable changes to this project.
 
 ---
 
+## [2026-04-23] MinIO Catalog Seeders + Store/Admin Store Handoff
+
+### MinIO-backed database seeders
+
+- Added `MinioSeeder` to `Tycoon.MigrationService` — reads JSON seed files from MinIO at startup and upserts them idempotently into the database.
+- Supports four seed files: `seeds/store-items.json`, `seeds/skill-nodes.json`, `seeds/season-rewards.json`, `seeds/questions.json`.
+- Missing seed files are silently skipped — only upload the files you want to seed.
+- All four entity seeders follow a bulk-fetch pattern (single `WHERE IN` query per type, no N+1 loops).
+- MinIO reads for all four files are issued concurrently via `Task.WhenAll` before any DB writes.
+- `GetAsync(string key, CancellationToken ct)` added to `IObjectStorage` and implemented in both `MinioObjectStorage` (with `MemoryStream` callback + precise `ObjectNotFoundException`/`NoSuchKey` error guard) and `LocalObjectStorage` (file-stream from `wwwroot`).
+- `EnsureBucketExistsAsync` result is cached on the singleton via a `_bucketEnsured` flag to avoid repeated network round-trips.
+- `MinioSeeder` is registered as `Transient` in `MigrationService/Program.cs` and called from `MigrationWorker` with a non-fatal try/catch (MinIO unavailability is logged as a warning, not a crash).
+
+### SeasonRewardRule persistence
+
+- Added `DbSet<SeasonRewardRule> SeasonRewardRules` to `IAppDb` and `AppDb`.
+- Added `SeasonRewardRuleConfiguration` EF entity configuration with a unique composite index on `(Tier, MaxTierRank)`.
+- **Action required:** run `dotnet ef migrations add AddSeasonRewardRules --project Tycoon.Backend.Migrations --startup-project Tycoon.Backend.Api` before next deploy.
+
+### Simplify cleanup (seeder)
+
+- Eliminated all N+1 query patterns: bulk-fetch existing records into `Dictionary<key, entity>` before looping.
+- Extracted `ApplyStoreItemFields` and `ApplyQuestionRelations` static helpers to remove field-mapping duplication.
+- Questions load existing rows with `Include(q => q.Options).Include(q => q.Tags)` in a single query.
+- SeasonRewardRules use a `HashSet<(int Tier, int MaxTierRank)>` for O(1) existence checks.
+- Replaced stringly-typed exception filter with `IsObjectNotFoundError()` static helper (precise type-name check + stable S3 `NoSuchKey` error code).
+- Added `Tycoon.Shared.Contracts` as an explicit `ProjectReference` in `Tycoon.MigrationService.csproj`.
+
+### Documentation
+
+- Added `docs/minio-seed-data-format.md` — JSON schema examples for all four seed file types with field notes and `mc` upload commands.
+- Added `docs/store_admin_backend_handoff_2026-04-23.md` — full API contract for P0/P1/P2 store stock system and admin store endpoints.
+- Updated `docs/REMAINING_TASKS.md` — avatar purchase path and MinIO seeders marked complete; SeasonRewardRule migration and store stock P0/P1/P2 backlog added as section 11.
+
+---
+
+## [2026-04-21] 3D Avatar Purchase Path
+
+### New endpoints
+
+- `GET /store/catalog?category=avatar` — avatar-specific catalog with `owned` flag per item (anonymous returns `owned: false`).
+- `POST /store/avatars/{avatarId}/purchase` — buy avatar with coins; returns `{success, avatarId, coinsDeducted, newBalance}`; JWT player must match request body.
+- `GET /v1/assets/avatars/{avatarId}` — returns a presigned MinIO GET URL for the `.zip` archive; owner-only.
+
+### Storage
+
+- Added `GetPresignedGetUrlAsync(string key, TimeSpan expiry, CancellationToken ct)` to `IPresignedStorage` and implemented in `MinioObjectStorage` with the same internal→public URL rewriting as the PUT method.
+
+### Domain
+
+- Added `ThumbnailUrl` (string?, max 500), `IsFeatured` (bool, default false), and `Version` (string?, max 20) to `StoreItem`.
+- Added EF column mappings in `StoreItemConfig`.
+
+### Application handlers
+
+- `GetAvatarCatalog(Guid? PlayerId)` — queries active avatar items, optionally resolves ownership via `PlayerTransaction` aggregation.
+- `PurchaseAvatar(Guid PlayerId, string AvatarId)` — validates ownership, balance, and delegates to `PlayerTransactionService`; returns structured error codes (`avatar_not_found`, `already_owned`, `insufficient_funds`).
+- `GetAvatarAsset(Guid PlayerId, string AvatarId)` — validates ownership, generates 15-minute presigned GET URL for the archive.
+
+### Shared DTOs
+
+- Added `AvatarCatalogItemDto`, `AvatarCatalogDto`, `PurchaseAvatarRequest`, `PurchaseAvatarResultDto`, `AvatarAssetResponseDto` to `Tycoon.Shared.Contracts`.
+
+---
+
 ## [2026-04-21] Store Catalog Premium Compatibility
 
 ### Store catalog compatibility

--- a/docs/REMAINING_TASKS.md
+++ b/docs/REMAINING_TASKS.md
@@ -1,6 +1,6 @@
 # Remaining Tasks & Work Backlog
 
-_Last updated: 2026-04-18 (updated: backend Study surface handoff, custom study sets, flashcard/self-test session state, and due-review recommendations)_
+_Last updated: 2026-04-23 (updated: avatar purchase path complete, MinIO catalog seeders complete, store stock P0/P1/P2 backlog added)_
 
 > This file is the canonical "what is left to do" reference.
 > For completed work, see [`docs/ALPHA_TASK_AUDIT.md`](ALPHA_TASK_AUDIT.md).
@@ -14,6 +14,12 @@ _Last updated: 2026-04-18 (updated: backend Study surface handoff, custom study 
 | Area | Priority | Status | Blocked? |
 |------|----------|--------|----------|
 | Frontend/backend alpha handoff | High | Store, profile/social, question gameplay complete; crypto + ML remain | No |
+| **3D Avatar purchase path (Browse → Buy → Download)** | **High** | **Complete** | **No** |
+| **MinIO catalog seeders (StoreItems, SkillNodes, SeasonRewards, Questions)** | **High** | **Complete** | **No** |
+| **SeasonRewardRule EF migration** | **High** | **Pending — user must run AddSeasonRewardRules** | **No** |
+| Store stock system P0 (daily store + stock enforcement) | High | Not started | No |
+| Store stock system P1 (player catalog + hub + special offers) | High | Not started | No |
+| Store stock system P2 (admin policies + flash sales + analytics) | Medium | Not started | No |
 | Phase 2 - Crash recovery stubs | High | Code complete; device validation pending | No |
 | Phase 3 - Test coverage (remaining gaps) | Medium | ~4.1% -> 40% target | No |
 | Phase 4 - Dependency audit | Medium | Partial | No |
@@ -252,6 +258,53 @@ _Last updated: 2026-04-18 (updated: backend Study surface handoff, custom study 
 - `lib/screens/question/`
 - `test/core/services/ml/`
 - `test/game/providers/ml_providers_test.dart`
+
+---
+
+## 11. Store Stock System (P0 / P1 / P2)
+
+Full design: `docs/store_stock_backend_implementation_and_schema.md`
+API contracts: `docs/store_admin_backend_handoff_2026-04-23.md`
+
+### Prerequisite — SeasonRewardRule EF Migration
+
+The `season_reward_rules` table does not yet have an EF Core migration. Run this before adding the stock system migrations:
+
+```bash
+dotnet ef migrations add AddSeasonRewardRules \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+dotnet ef database update \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+```
+
+### 11a. P0 — Daily Store + Stock Enforcement
+
+- [ ] Create domain entities: `StoreStockPolicy`, `PlayerStoreStockState` (see §6.2 of design doc)
+- [ ] Add EF Core configurations + migration `AddStoreStockSystem`
+- [ ] Implement `IStoreStockService`: lazy reset algorithm, availability check, stock consumption
+- [ ] Add `GET /store/daily` endpoint (daily rotating items with per-player stock)
+- [ ] Extend `POST /store/purchase` to check and decrement `PlayerStoreStockState`
+- [ ] Add `store_item_out_of_stock` (409) and `store_item_unavailable` (409) error codes
+
+### 11b. P1 — Player-Specific Catalog + Hub Surface
+
+- [ ] Create domain entities: `PlayerStorePurchase`, `PlayerStoreInventoryItem`
+- [ ] Add `GET /store/catalog/{playerId}` with `StoreStockState` and `StoreAvailabilityState`
+- [ ] Add `GET /store/hub` (featured, daily, categories)
+- [ ] Add `GET /store/special-offers` (active flash sales + limited-time offers)
+- [ ] Create `FlashSale` entity + EF config
+- [ ] Wire FastAPI personalization as opt-in via `IStorePersonalizationService` (fail-open)
+
+### 11c. P2 — Admin Stock Management
+
+- [ ] `GET /admin/store/stock-policies` + `PUT /admin/store/stock-policies/{sku}`
+- [ ] `POST /admin/store/stock-policies/bulk-reset`
+- [ ] `GET /admin/store/player-stock/{playerId}` + `POST /admin/store/player-stock/{playerId}/override`
+- [ ] Flash sale CRUD: `GET`, `POST /admin/store/flash-sales`, `DELETE /admin/store/flash-sales/{id}`
+- [ ] Reward limit management: `GET` + `PUT /admin/store/reward-limits/{rewardId}`
+- [ ] Analytics: `GET /admin/store/analytics/purchases` + `GET /admin/store/analytics/stock-resets`
 
 ---
 

--- a/docs/store_admin_backend_handoff_2026-04-23.md
+++ b/docs/store_admin_backend_handoff_2026-04-23.md
@@ -1,0 +1,445 @@
+# Store & Admin Store Backend API Handoff
+
+> **Audience:** Backend team
+> **Date:** 2026-04-23
+> **Base URL:** `http(s)://<host>:5000`
+> **OpenAPI docs:** `/swagger` (dev only)
+> **Design reference:** `docs/store_stock_backend_implementation_and_schema.md`
+
+---
+
+## Overview
+
+This document covers the **next phase of store backend work**: player-scoped stock, daily limits, personalization hooks, and admin tooling. The currently implemented store endpoints are listed below as a baseline. All new endpoints build on top of this foundation.
+
+---
+
+## Currently Implemented Endpoints (Baseline)
+
+| Method | Route | Auth | Status |
+|--------|-------|------|--------|
+| `GET` | `/store/catalog` | No | Live |
+| `GET` | `/store/catalog/{sku}` | No | Live |
+| `GET` | `/store/premium` | Yes | Live |
+| `GET` | `/store/rewards/{playerId}` | Yes | Live |
+| `POST` | `/store/rewards/{playerId}/claim/{rewardId}` | Yes | Live |
+| `GET` | `/store/system/status` | No | Live |
+| `GET` | `/store/inventory/{playerId}` | Yes | Live |
+| `GET` | `/store/subscription/status/{playerId}` | Yes | Live |
+| `POST` | `/store/subscription/activate` | Yes | Live |
+| `POST` | `/store/subscription/checkout/session` | Yes | Live |
+| `POST` | `/store/subscription/portal/session` | Yes | Live |
+| `POST` | `/store/subscription/paypal/create` | Yes | Live |
+| `POST` | `/store/subscription/paypal/cancel` | Yes | Live |
+| `POST` | `/store/purchase` | Yes | Live |
+| `POST` | `/store/payments/checkout/session` | Yes | Live |
+| `POST` | `/store/payments/paypal/order` | Yes | Live |
+| `POST` | `/store/payments/paypal/capture` | Yes | Live |
+| `POST` | `/store/payments/webhook` | No | Live |
+| `POST` | `/store/payments/paypal/webhook` | No | Live |
+| `POST` | `/store/iap/validate` | Yes | Live |
+| `GET` | `/store/avatars/{avatarId}` | Yes | Live |
+| `POST` | `/store/avatars/{avatarId}/purchase` | Yes | Live |
+| `GET` | `/v1/assets/avatars/{avatarId}` | Yes | Live |
+
+---
+
+## Error Envelope
+
+All error responses use the nested envelope format:
+
+```json
+{
+  "error": {
+    "code": "error_code_snake_case",
+    "message": "Human-readable message.",
+    "details": {}
+  }
+}
+```
+
+---
+
+## P0 — Daily Store + Stock Enforcement
+
+### Goal
+
+Add a daily store surface and enforce stock limits in the existing `POST /store/purchase` flow.
+
+### P0.1 — `GET /store/daily`
+
+Returns the daily rotating store items for the authenticated player.
+
+#### Auth
+Required (`Authorization: Bearer <jwt>`)
+
+#### Response `200`
+
+```json
+{
+  "playerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "generatedAt": "2026-04-23T00:00:00Z",
+  "resetsAt": "2026-04-24T00:00:00Z",
+  "items": [
+    {
+      "sku": "powerup:skip",
+      "name": "Question Skip",
+      "description": "Skip any question once.",
+      "itemType": "powerup",
+      "priceCoins": 50,
+      "priceDiamonds": 0,
+      "remainingQuantity": 3,
+      "maxQuantity": 5,
+      "resetInterval": "daily",
+      "soldOut": false,
+      "discountPercent": 0
+    }
+  ]
+}
+```
+
+#### Implementation notes
+
+- Filter `StoreItem` where `IsActive && ItemType` is in the daily rotation set.
+- Stock state from `PlayerStoreStockState` (create row on first access).
+- Lazy reset: if `NextResetAtUtc <= UtcNow`, reset `QuantityUsed = 0` and recalculate `NextResetAtUtc`.
+- Return `resetsAt` = next midnight UTC.
+
+### P0.2 — Stock enforcement in `POST /store/purchase`
+
+Extend the existing purchase handler to check and decrement `PlayerStoreStockState` before completing a transaction.
+
+#### New error codes
+
+| Code | HTTP | Condition |
+|------|------|-----------|
+| `store_item_out_of_stock` | 409 | `remainingQuantity < quantity` |
+| `store_item_unavailable` | 409 | Outside availability window |
+
+#### Request (unchanged)
+
+```json
+{
+  "playerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "sku": "powerup:skip",
+  "quantity": 1,
+  "clientRequestId": "b64c5408-d769-4b4a-9209-801f36b0f61d"
+}
+```
+
+#### Response `200` (augmented)
+
+```json
+{
+  "success": true,
+  "transactionId": "txn_001",
+  "sku": "powerup:skip",
+  "quantityPurchased": 1,
+  "remainingQuantity": 2,
+  "nextResetAt": "2026-04-24T00:00:00Z",
+  "wallet": {
+    "coins": 1200,
+    "gems": 50
+  }
+}
+```
+
+---
+
+## P1 — Player-Specific Catalog + Hub Surface
+
+### P1.1 — `GET /store/catalog/{playerId}`
+
+Returns the full store catalog resolved for a specific player, including stock state, availability, and optional personalization.
+
+#### Auth
+Required (`Authorization: Bearer <jwt>`); JWT `playerId` must match path `playerId`.
+
+#### Query Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `itemType` | string | (all) | Filter by item type |
+| `category` | string | (all) | Filter by category prefix (`avatar`, `powerup`, etc.) |
+
+#### Response `200`
+
+```json
+{
+  "playerId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+  "generatedAt": "2026-04-23T14:00:00Z",
+  "items": [
+    {
+      "sku": "powerup:skip",
+      "name": "Question Skip",
+      "description": "Skip any question once.",
+      "itemType": "powerup",
+      "priceCoins": 50,
+      "priceDiamonds": 0,
+      "isAvailable": true,
+      "remainingQuantity": 3,
+      "maxQuantity": 5,
+      "resetInterval": "daily",
+      "lastResetAt": "2026-04-23T00:00:00Z",
+      "nextResetAt": "2026-04-24T00:00:00Z",
+      "soldOut": false,
+      "discountPercent": 0,
+      "owned": false,
+      "availabilityState": "available",
+      "stockState": "in_stock"
+    }
+  ]
+}
+```
+
+#### `availabilityState` values
+
+| Value | Meaning |
+|-------|---------|
+| `available` | Item is purchasable |
+| `sold_out` | Player has used all stock for this interval |
+| `outside_window` | Item is not in its availability window |
+| `premium_required` | Player does not have premium |
+| `already_owned` | One-time item already owned |
+
+#### `stockState` values
+
+| Value | Meaning |
+|-------|---------|
+| `in_stock` | Quantity available |
+| `low_stock` | 1 remaining |
+| `out_of_stock` | 0 remaining |
+| `unlimited` | No stock tracking |
+
+### P1.2 — `GET /store/hub`
+
+Returns the store hub content for the authenticated player: featured items, categories, and daily highlights.
+
+#### Auth
+Required
+
+#### Response `200`
+
+```json
+{
+  "featured": [...],
+  "daily": [...],
+  "categories": ["powerup", "avatar", "currency", "cosmetic"]
+}
+```
+
+### P1.3 — `GET /store/special-offers`
+
+Returns active flash sales and limited-time offers for the player.
+
+#### Auth
+Required
+
+#### Response `200`
+
+```json
+{
+  "offers": [
+    {
+      "sku": "coin_pack_large",
+      "name": "Weekend Bundle",
+      "originalPriceCoins": 500,
+      "salePriceCoins": 350,
+      "discountPercent": 30,
+      "endsAt": "2026-04-25T23:59:59Z"
+    }
+  ]
+}
+```
+
+---
+
+## P2 — Admin Store Management
+
+All admin routes require `RequireAuthorization("Admin")` or an appropriate admin role claim.
+
+### P2.1 — Stock Policy Management
+
+#### `GET /admin/store/stock-policies`
+
+Returns all active stock policies.
+
+#### `PUT /admin/store/stock-policies/{sku}`
+
+Upserts the stock policy for a catalog item.
+
+##### Request
+
+```json
+{
+  "policyType": "per_user",
+  "maxQuantity": 5,
+  "resetInterval": "daily",
+  "isResetEnabled": true,
+  "allowDynamicOverride": true
+}
+```
+
+#### `POST /admin/store/stock-policies/bulk-reset`
+
+Force-resets stock state for all players for one or more SKUs.
+
+##### Request
+
+```json
+{
+  "skus": ["powerup:skip", "powerup:hint"],
+  "reason": "Manual weekly reset"
+}
+```
+
+### P2.2 — Per-Player Stock Management
+
+#### `GET /admin/store/player-stock/{playerId}`
+
+Returns all stock state rows for a player.
+
+#### `POST /admin/store/player-stock/{playerId}/override`
+
+Applies an admin quantity override for a specific SKU.
+
+##### Request
+
+```json
+{
+  "sku": "powerup:skip",
+  "effectiveMaxQuantity": 10,
+  "reason": "Support override for player complaint"
+}
+```
+
+### P2.3 — Flash Sale Management
+
+#### `GET /admin/store/flash-sales`
+
+Returns all active and scheduled flash sales.
+
+#### `POST /admin/store/flash-sales`
+
+Creates a new flash sale.
+
+##### Request
+
+```json
+{
+  "sku": "coin_pack_large",
+  "discountPercent": 30,
+  "startsAt": "2026-04-25T00:00:00Z",
+  "endsAt": "2026-04-25T23:59:59Z",
+  "reason": "Weekend promo"
+}
+```
+
+#### `DELETE /admin/store/flash-sales/{id}`
+
+Cancels a flash sale early.
+
+### P2.4 — Reward Limit Management
+
+#### `GET /admin/store/reward-limits`
+
+Returns all reward claim rules.
+
+#### `PUT /admin/store/reward-limits/{rewardId}`
+
+Updates the claim interval and max claims for a reward type.
+
+##### Request
+
+```json
+{
+  "maxClaimsPerInterval": 3,
+  "resetInterval": "daily"
+}
+```
+
+### P2.5 — Store Analytics
+
+#### `GET /admin/store/analytics/purchases`
+
+Returns aggregate purchase stats.
+
+##### Query parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `from` | ISO date | Start of range |
+| `to` | ISO date | End of range |
+| `sku` | string | Filter by SKU |
+| `playerId` | Guid | Filter by player |
+
+##### Response `200`
+
+```json
+{
+  "totalPurchases": 1423,
+  "totalRevenue": { "coins": 128500, "gems": 3200 },
+  "topSkus": [
+    { "sku": "powerup:skip", "purchases": 487, "revenueCoins": 24350 }
+  ]
+}
+```
+
+#### `GET /admin/store/analytics/stock-resets`
+
+Returns a history of stock resets (lazy and manual).
+
+---
+
+## Domain Entities Required
+
+These entities need to be created as EF Core entities before P0 can be implemented. Full C# class definitions are in `docs/store_stock_backend_implementation_and_schema.md` §6.2.
+
+| Entity | Table | Used in |
+|--------|-------|---------|
+| `StoreStockPolicy` | `store_stock_policies` | P0, P1, P2.1 |
+| `PlayerStoreStockState` | `player_store_stock_states` | P0, P1, P2.2 |
+| `PlayerStorePurchase` | `player_store_purchases` | P0 extended purchase |
+| `PlayerStoreInventoryItem` | `player_store_inventory_items` | P0 extended purchase |
+| `FlashSale` | `store_flash_sales` | P1.3, P2.3 |
+
+---
+
+## EF Migration Plan
+
+```bash
+# After adding all entities and EF configurations:
+dotnet ef migrations add AddStoreStockSystem \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+
+dotnet ef database update \
+  --project Tycoon.Backend.Migrations \
+  --startup-project Tycoon.Backend.Api
+```
+
+---
+
+## Implementation Priority
+
+| Priority | Endpoint | Blocking? |
+|----------|----------|-----------|
+| P0 | `GET /store/daily` | Flutter daily store screen |
+| P0 | Stock enforcement in `POST /store/purchase` | Purchase correctness |
+| P1 | `GET /store/catalog/{playerId}` | Flutter hub + catalog personalization |
+| P1 | `GET /store/hub` | Flutter store hub screen |
+| P1 | `GET /store/special-offers` | Flutter offers surface |
+| P2 | Admin stock policies | Operator tuning |
+| P2 | Admin flash sales | Marketing campaigns |
+| P2 | Admin reward limits | Reward balancing |
+| P2 | Admin analytics | Business intelligence |
+
+---
+
+## Open Questions
+
+1. **Stock policy defaults** — Should new catalog items default to `unlimited` or `per_user: 1` per day? Recommendation: `unlimited` with opt-in stock policies.
+2. **Flash sale storage** — Store flash sales in DB (recommended for operator tooling) or config only?
+3. **Personalization integration** — FastAPI `POST /ml/store-personalization` is already designed (see `store_stock_backend_implementation_and_schema.md` §6.7). Enable now or leave as P3?
+4. **`playerStoreStockState` initialization** — Create rows lazily on first read (recommended) or eagerly on catalog load?
+5. **`SeasonRewardRule` EF migration** — The `season_reward_rules` table does not yet have an EF migration. Run `dotnet ef migrations add AddSeasonRewardRules` before the next migration adds stock entities.


### PR DESCRIPTION
- Created docs/store_admin_backend_handoff_2026-04-23.md with full P0/P1/P2 store stock + admin store API contracts (daily store, player catalog, hub, special offers, admin stock policies, flash sales, analytics)
- Updated docs/REMAINING_TASKS.md: avatar purchase path and MinIO seeders marked complete; SeasonRewardRule migration flagged; store stock P0/P1/P2 backlog added as section 11
- Updated docs/CHANGELOG.md: added [2026-04-23] MinIO seeders + simplify entry and [2026-04-21] 3D avatar purchase path entry

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2