### PR TITLE
Fix duplicate UseSwagger/UseSwaggerUI middleware registration

### DIFF
--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -534,8 +534,6 @@ app.UseRouting();
 // ✅ Show detailed errors in development
 if (app.Environment.IsDevelopment())
 {
-    app.UseSwagger();
-    app.UseSwaggerUI();
     app.UseDeveloperExceptionPage();
 }
 


### PR DESCRIPTION
Removed the bare app.UseSwagger() + app.UseSwaggerUI() pair that fired before the configured block, causing Swagger to initialise twice with conflicting settings in development. Kept the fully-configured block (custom route template, endpoint title, deep-linking, filter enabled).

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2