### PR TITLE
feat: implement Unified Personalization Layer (PRs 1-5)

### DIFF
--- a/Tycoon.Backend.Api/Features/Coach/CoachEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Coach/CoachEndpoints.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Tycoon.Backend.Application.Personalization;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.Coach;
+
+public static class CoachEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        var group = app.MapGroup("/coach")
+            .RequireAuthorization()
+            .WithTags("Coach")
+            .WithOpenApi();
+
+        group.MapGet("/{playerId:guid}/daily-brief", async (
+            Guid playerId,
+            IPersonalizationService personalization,
+            CancellationToken ct) =>
+        {
+            var home = await personalization.GetHomeAsync(playerId, ct);
+            return Results.Ok(home.CoachBrief);
+        });
+
+        group.MapPost("/{playerId:guid}/feedback", async (
+            Guid playerId,
+            [FromBody] CoachFeedbackRequest request,
+            IPlayerMindProfileService profiles,
+            CancellationToken ct) =>
+        {
+            await profiles.RecordEventAsync(playerId, new PlayerBehaviorEventDto(
+                EventType: "coach_feedback",
+                EventSource: "coach",
+                Category: null,
+                Difficulty: null,
+                Mode: null,
+                Metadata: new Dictionary<string, object>
+                {
+                    ["feedback"] = request.Feedback,
+                    ["briefId"] = request.BriefId
+                },
+                OccurredAt: DateTimeOffset.UtcNow), ct);
+
+            return Results.Accepted();
+        });
+    }
+}

--- a/Tycoon.Backend.Api/Features/Personalization/PersonalizationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Personalization/PersonalizationEndpoints.cs
@@ -1,0 +1,82 @@
+using Microsoft.AspNetCore.Mvc;
+using Tycoon.Backend.Application.Personalization;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.Personalization;
+
+public static class PersonalizationEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        var group = app.MapGroup("/personalization")
+            .RequireAuthorization()
+            .WithTags("Personalization")
+            .WithOpenApi();
+
+        group.MapGet("/profile/{playerId:guid}", async (
+            Guid playerId,
+            IPlayerMindProfileService profiles,
+            CancellationToken ct) =>
+        {
+            var profile = await profiles.GetOrCreateAsync(playerId, ct);
+            return Results.Ok(profile);
+        });
+
+        group.MapPost("/profile/{playerId:guid}/event", async (
+            Guid playerId,
+            [FromBody] PlayerBehaviorEventDto request,
+            IPlayerMindProfileService profiles,
+            CancellationToken ct) =>
+        {
+            await profiles.RecordEventAsync(playerId, request, ct);
+            return Results.Accepted();
+        });
+
+        group.MapPost("/profile/{playerId:guid}/recalculate", async (
+            Guid playerId,
+            IPlayerMindProfileService profiles,
+            CancellationToken ct) =>
+        {
+            var profile = await profiles.RecalculateAsync(playerId, ct);
+            return Results.Ok(profile);
+        });
+
+        group.MapGet("/home/{playerId:guid}", async (
+            Guid playerId,
+            IPersonalizationService personalization,
+            CancellationToken ct) =>
+        {
+            var result = await personalization.GetHomeAsync(playerId, ct);
+            return Results.Ok(result);
+        });
+
+        group.MapGet("/recommendations/{playerId:guid}", async (
+            Guid playerId,
+            IPersonalizationService personalization,
+            CancellationToken ct) =>
+        {
+            var result = await personalization.GetRecommendationsAsync(playerId, ct);
+            return Results.Ok(result);
+        });
+
+        group.MapPost("/recommendations/{recommendationId:guid}/accept", async (
+            Guid recommendationId,
+            [FromQuery] Guid playerId,
+            IPersonalizationService personalization,
+            CancellationToken ct) =>
+        {
+            await personalization.AcceptRecommendationAsync(recommendationId, playerId, ct);
+            return Results.NoContent();
+        });
+
+        group.MapPost("/recommendations/{recommendationId:guid}/dismiss", async (
+            Guid recommendationId,
+            [FromQuery] Guid playerId,
+            IPersonalizationService personalization,
+            CancellationToken ct) =>
+        {
+            await personalization.DismissRecommendationAsync(recommendationId, playerId, ct);
+            return Results.NoContent();
+        });
+    }
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -62,6 +62,8 @@ using Tycoon.Backend.Api.Features.Qr;
 using Tycoon.Backend.Api.Features.LearningModules;
 using Tycoon.Backend.Api.Features.AdminLearningModules;
 using Tycoon.Backend.Api.Features.Avatars;
+using Tycoon.Backend.Api.Features.Personalization;
+using Tycoon.Backend.Api.Features.Coach;
 using Tycoon.Backend.Api.Features.Questions;
 using Tycoon.Backend.Api.Features.Crypto;
 using Tycoon.Backend.Api.Features.Store;
@@ -96,6 +98,7 @@ using Tycoon.Backend.Infrastructure;
 using Tycoon.Backend.Infrastructure.Persistence.Extensions;
 using Tycoon.Backend.Infrastructure.Persistence.HealthChecks;
 using Tycoon.Backend.Infrastructure.Persistence.Startup;
+using Tycoon.Backend.Infrastructure.SidecarClient;
 using Tycoon.Shared.Contracts.Dtos;
 using Tycoon.Shared.Observability;
 using Tycoon.Backend.Api.Grpc;
@@ -513,6 +516,12 @@ builder.Services.AddSchemaGate(builder.Configuration, builder.Environment);
 // take it as a service dependency (avoids startup parameter-inference failures).
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
+builder.Services.AddHttpClient<IPersonalizationSidecarClient, PersonalizationSidecarClient>(client =>
+{
+    var baseUrl = builder.Configuration["SidecarPersonalization:BaseUrl"] ?? "http://localhost:8001";
+    client.BaseAddress = new Uri(baseUrl);
+    client.Timeout = TimeSpan.FromSeconds(5);
+});
 builder.Services.Configure<StorePremiumOptions>(builder.Configuration.GetSection("StorePremium"));
 builder.Services.Configure<PayPalOptions>(builder.Configuration.GetSection("PayPal"));
 builder.Services.AddSingleton<IPayPalPaymentGateway, PayPalPaymentGateway>();
@@ -831,6 +840,8 @@ StudySessionsEndpoints.Map(app);
 VoteEndpoints.Map(app);
 StoreEndpoints.Map(app);
 AvatarEndpoints.Map(app);
+PersonalizationEndpoints.Map(app);
+CoachEndpoints.Map(app);
 CryptoEconomyEndpoints.Map(app);
 MlScoringEndpoints.Map(app);
 GameEventsEndpoints.Map(app);

--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Tycoon.Backend.Application.Analytics.Models;
 using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Domain.Personalization;
 
 namespace Tycoon.Backend.Application.Abstractions
 {
@@ -90,6 +91,12 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<ModuleLesson> ModuleLessons { get; }
         DbSet<ModuleCompletion> ModuleCompletions { get; }
         DbSet<StudySession> StudySessions { get; }
+
+        // Personalization
+        DbSet<PlayerMindProfile> PlayerMindProfiles { get; }
+        DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents { get; }
+        DbSet<PersonalizationRecommendation> PersonalizationRecommendations { get; }
+        DbSet<PersonalizationRule> PersonalizationRules { get; }
 
         Task<int> SaveChangesAsync(CancellationToken ct = default);
         EntityEntry Entry(object entity);

--- a/Tycoon.Backend.Application/Abstractions/IPersonalizationSidecarClient.cs
+++ b/Tycoon.Backend.Application/Abstractions/IPersonalizationSidecarClient.cs
@@ -1,0 +1,12 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Abstractions;
+
+public interface IPersonalizationSidecarClient
+{
+    Task<SidecarPlayerScoresDto> ScorePlayerAsync(SidecarPlayerScoringRequest request, CancellationToken ct = default);
+
+    Task<IReadOnlyList<SidecarRecommendationCandidateDto>> GetRecommendationCandidatesAsync(
+        SidecarRecommendationRequest request,
+        CancellationToken ct = default);
+}

--- a/Tycoon.Backend.Application/DependencyInjection.cs
+++ b/Tycoon.Backend.Application/DependencyInjection.cs
@@ -118,6 +118,11 @@ namespace Tycoon.Backend.Application
             services.AddScoped<SeasonRewardJob>();
             services.AddScoped<SeasonCloseOrchestrator>();
 
+            // Personalization
+            services.AddScoped<Personalization.IPlayerMindProfileService, Personalization.PlayerMindProfileService>();
+            services.AddScoped<Personalization.IPersonalizationService, Personalization.PersonalizationService>();
+            services.AddScoped<Personalization.IPersonalizationGuardrailService, Personalization.PersonalizationGuardrailService>();
+
             return services;
         }
     }

--- a/Tycoon.Backend.Application/Personalization/IPersonalizationGuardrailService.cs
+++ b/Tycoon.Backend.Application/Personalization/IPersonalizationGuardrailService.cs
@@ -1,0 +1,8 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public interface IPersonalizationGuardrailService
+{
+    PersonalizationGuardrailResult Apply(PlayerMindProfileDto profile, PersonalizationCandidateDto candidate);
+}

--- a/Tycoon.Backend.Application/Personalization/IPersonalizationService.cs
+++ b/Tycoon.Backend.Application/Personalization/IPersonalizationService.cs
@@ -1,0 +1,14 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public interface IPersonalizationService
+{
+    Task<PlayerHomePersonalizationDto> GetHomeAsync(Guid playerId, CancellationToken ct = default);
+
+    Task<IReadOnlyList<PlayerRecommendationDto>> GetRecommendationsAsync(Guid playerId, CancellationToken ct = default);
+
+    Task AcceptRecommendationAsync(Guid recommendationId, Guid playerId, CancellationToken ct = default);
+
+    Task DismissRecommendationAsync(Guid recommendationId, Guid playerId, CancellationToken ct = default);
+}

--- a/Tycoon.Backend.Application/Personalization/IPlayerMindProfileService.cs
+++ b/Tycoon.Backend.Application/Personalization/IPlayerMindProfileService.cs
@@ -1,0 +1,12 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public interface IPlayerMindProfileService
+{
+    Task<PlayerMindProfileDto> GetOrCreateAsync(Guid playerId, CancellationToken ct = default);
+
+    Task RecordEventAsync(Guid playerId, PlayerBehaviorEventDto behaviorEvent, CancellationToken ct = default);
+
+    Task<PlayerMindProfileDto> RecalculateAsync(Guid playerId, CancellationToken ct = default);
+}

--- a/Tycoon.Backend.Application/Personalization/PersonalizationGuardrailService.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationGuardrailService.cs
@@ -1,0 +1,38 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public sealed class PersonalizationGuardrailService : IPersonalizationGuardrailService
+{
+    public PersonalizationGuardrailResult Apply(PlayerMindProfileDto profile, PersonalizationCandidateDto candidate)
+    {
+        var rules = new Dictionary<string, object>();
+
+        if (candidate.Type == "store_offer" && profile.FrustrationRiskScore >= 0.75m)
+        {
+            rules["suppress_paid_offers_when_frustrated"] = true;
+            return new(false, "Paid offers suppressed due to high frustration risk.", rules);
+        }
+
+        if (candidate.Type == "notification" && profile.NotificationFatigueScore >= 0.70m)
+        {
+            rules["notification_fatigue_limit"] = true;
+            return new(false, "Notification suppressed due to fatigue risk.", rules);
+        }
+
+        if (candidate.Type == "ranked_difficulty_modifier")
+        {
+            rules["ranked_fairness_lock"] = true;
+            return new(false, "Ranked difficulty cannot be modified by personalization.", rules);
+        }
+
+        if (!profile.PersonalizationEnabled)
+        {
+            rules["personalization_disabled"] = true;
+            return new(false, "Personalization is disabled for this player.", rules);
+        }
+
+        rules["allowed"] = true;
+        return new(true, null, rules);
+    }
+}

--- a/Tycoon.Backend.Application/Personalization/PersonalizationService.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationService.cs
@@ -1,0 +1,200 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Personalization;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public sealed class PersonalizationService : IPersonalizationService
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private readonly IAppDb _db;
+    private readonly IPlayerMindProfileService _profiles;
+    private readonly IPersonalizationGuardrailService _guardrails;
+    private readonly IPersonalizationSidecarClient _sidecar;
+
+    public PersonalizationService(
+        IAppDb db,
+        IPlayerMindProfileService profiles,
+        IPersonalizationGuardrailService guardrails,
+        IPersonalizationSidecarClient sidecar)
+    {
+        _db = db;
+        _profiles = profiles;
+        _guardrails = guardrails;
+        _sidecar = sidecar;
+    }
+
+    public async Task<PlayerHomePersonalizationDto> GetHomeAsync(Guid playerId, CancellationToken ct = default)
+    {
+        var profile = await _profiles.GetOrCreateAsync(playerId, ct);
+        var recommendations = await BuildRecommendationsAsync(playerId, profile, ct);
+
+        var coachBrief = BuildCoachBrief(profile);
+
+        return new PlayerHomePersonalizationDto(
+            playerId,
+            RecommendedMode: RecommendMode(profile),
+            RecommendedCategory: RecommendCategory(profile),
+            RecommendedDifficulty: RecommendDifficulty(profile),
+            Recommendations: recommendations,
+            CoachBrief: coachBrief,
+            Guardrails: new Dictionary<string, object>
+            {
+                ["personalizationEnabled"] = profile.PersonalizationEnabled,
+                ["sidecarEnabled"] = profile.SidecarScoringEnabled
+            });
+    }
+
+    public async Task<IReadOnlyList<PlayerRecommendationDto>> GetRecommendationsAsync(Guid playerId, CancellationToken ct = default)
+    {
+        var profile = await _profiles.GetOrCreateAsync(playerId, ct);
+        return await BuildRecommendationsAsync(playerId, profile, ct);
+    }
+
+    public async Task AcceptRecommendationAsync(Guid recommendationId, Guid playerId, CancellationToken ct = default)
+    {
+        var rec = await _db.PersonalizationRecommendations
+            .FirstOrDefaultAsync(r => r.Id == recommendationId && r.PlayerId == playerId, ct);
+
+        if (rec is not null)
+        {
+            rec.AcceptedAt = DateTimeOffset.UtcNow;
+            await _db.SaveChangesAsync(ct);
+        }
+    }
+
+    public async Task DismissRecommendationAsync(Guid recommendationId, Guid playerId, CancellationToken ct = default)
+    {
+        var rec = await _db.PersonalizationRecommendations
+            .FirstOrDefaultAsync(r => r.Id == recommendationId && r.PlayerId == playerId, ct);
+
+        if (rec is not null)
+        {
+            rec.DismissedAt = DateTimeOffset.UtcNow;
+            await _db.SaveChangesAsync(ct);
+        }
+    }
+
+    private async Task<IReadOnlyList<PlayerRecommendationDto>> BuildRecommendationsAsync(
+        Guid playerId, PlayerMindProfileDto profile, CancellationToken ct)
+    {
+        List<SidecarRecommendationCandidateDto> candidates = [];
+
+        if (profile.PersonalizationEnabled && profile.SidecarScoringEnabled)
+        {
+            try
+            {
+                candidates = (await _sidecar.GetRecommendationCandidatesAsync(
+                    new SidecarRecommendationRequest(
+                        playerId.ToString(),
+                        new SidecarPlayerSnapshotDto(
+                            profile.ConfidenceLevel,
+                            profile.ChurnRiskScore,
+                            profile.FrustrationRiskScore,
+                            profile.NotificationFatigueScore,
+                            profile.Archetype),
+                        []), ct)).ToList();
+            }
+            catch
+            {
+                // Sidecar unavailable — serve empty candidates; local rules still apply
+            }
+        }
+
+        var result = new List<PlayerRecommendationDto>();
+        var priority = 0;
+
+        foreach (var candidate in candidates)
+        {
+            var guardCandidate = new PersonalizationCandidateDto(candidate.Type, candidate.Score, candidate.Payload);
+            var guardrailResult = _guardrails.Apply(profile, guardCandidate);
+
+            var rec = new PersonalizationRecommendation
+            {
+                Id = Guid.NewGuid(),
+                PlayerId = playerId,
+                RecommendationType = candidate.Type,
+                Source = "sidecar",
+                Priority = priority++,
+                Score = candidate.Score,
+                PayloadJson = JsonSerializer.Serialize(candidate.Payload, _json),
+                GuardrailJson = JsonSerializer.Serialize(guardrailResult.AppliedRules, _json),
+                ExpiresAt = DateTimeOffset.UtcNow.AddHours(6)
+            };
+
+            _db.PersonalizationRecommendations.Add(rec);
+
+            if (guardrailResult.Allowed)
+            {
+                result.Add(new PlayerRecommendationDto(
+                    rec.Id, candidate.Type, "sidecar", rec.Priority, candidate.Score,
+                    candidate.Payload, guardrailResult.AppliedRules, rec.ExpiresAt));
+            }
+        }
+
+        if (result.Count > 0)
+            await _db.SaveChangesAsync(ct);
+
+        return result;
+    }
+
+    private static string RecommendMode(PlayerMindProfileDto profile) => profile.Archetype switch
+    {
+        "risk_taker" or "social_challenger" => "ranked",
+        "low_pressure_learner" or "confidence_builder" => "practice",
+        "mastery_path" => "study",
+        _ => "casual"
+    };
+
+    private static string? RecommendCategory(PlayerMindProfileDto profile) =>
+        profile.CategoryWeaknesses.OrderByDescending(kv => kv.Value).FirstOrDefault().Key;
+
+    private static string? RecommendDifficulty(PlayerMindProfileDto profile) =>
+        profile.ConfidenceLevel switch
+        {
+            < 0.30m => "easy",
+            < 0.60m => "medium",
+            < 0.85m => "hard",
+            _ => "expert"
+        };
+
+    private static CoachBriefDto BuildCoachBrief(PlayerMindProfileDto profile)
+    {
+        if (profile.FrustrationRiskScore >= 0.70m)
+            return new CoachBriefDto(
+                "Take a breather",
+                "Your recent sessions have been tough. Try a low-pressure practice round to rebuild confidence.",
+                "start_practice",
+                "/play/practice",
+                "supportive");
+
+        if (profile.ChurnRiskScore >= 0.65m)
+            return new CoachBriefDto(
+                "We missed you!",
+                "Jump back in — your favourite categories are waiting. A quick round keeps your streak alive.",
+                "start_casual",
+                "/play/casual",
+                "encouraging");
+
+        if (profile.CategoryWeaknesses.Count > 0)
+        {
+            var weakest = profile.CategoryWeaknesses.OrderByDescending(kv => kv.Value).First().Key;
+            return new CoachBriefDto(
+                $"Level up your {weakest} knowledge",
+                $"You've been missing some {weakest} questions. A focused study set can help.",
+                "start_study",
+                "/study",
+                "motivating");
+        }
+
+        return new CoachBriefDto(
+            "Ready for a challenge?",
+            "Your skills are looking strong. Consider a ranked match to test yourself.",
+            "start_ranked",
+            "/play/ranked",
+            "motivating");
+    }
+}

--- a/Tycoon.Backend.Application/Personalization/PlayerMindProfileService.cs
+++ b/Tycoon.Backend.Application/Personalization/PlayerMindProfileService.cs
@@ -1,0 +1,143 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Personalization;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public sealed class PlayerMindProfileService : IPlayerMindProfileService
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private readonly IAppDb _db;
+    private readonly IPersonalizationSidecarClient _sidecar;
+
+    public PlayerMindProfileService(IAppDb db, IPersonalizationSidecarClient sidecar)
+    {
+        _db = db;
+        _sidecar = sidecar;
+    }
+
+    public async Task<PlayerMindProfileDto> GetOrCreateAsync(Guid playerId, CancellationToken ct = default)
+    {
+        var profile = await _db.PlayerMindProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(p => p.PlayerId == playerId, ct);
+
+        if (profile is null)
+        {
+            profile = new PlayerMindProfile { Id = Guid.NewGuid(), PlayerId = playerId };
+            _db.PlayerMindProfiles.Add(profile);
+            await _db.SaveChangesAsync(ct);
+        }
+
+        return MapToDto(profile);
+    }
+
+    public async Task RecordEventAsync(Guid playerId, PlayerBehaviorEventDto dto, CancellationToken ct = default)
+    {
+        var evt = new PlayerBehaviorEvent
+        {
+            Id = Guid.NewGuid(),
+            PlayerId = playerId,
+            EventType = dto.EventType,
+            EventSource = dto.EventSource,
+            Category = dto.Category,
+            Difficulty = dto.Difficulty,
+            Mode = dto.Mode,
+            MetadataJson = dto.Metadata is not null
+                ? JsonSerializer.Serialize(dto.Metadata, _json)
+                : "{}",
+            OccurredAt = dto.OccurredAt ?? DateTimeOffset.UtcNow,
+            IngestedAt = DateTimeOffset.UtcNow
+        };
+
+        _db.PlayerBehaviorEvents.Add(evt);
+        await _db.SaveChangesAsync(ct);
+    }
+
+    public async Task<PlayerMindProfileDto> RecalculateAsync(Guid playerId, CancellationToken ct = default)
+    {
+        var profile = await _db.PlayerMindProfiles
+            .FirstOrDefaultAsync(p => p.PlayerId == playerId, ct);
+
+        if (profile is null)
+        {
+            profile = new PlayerMindProfile { Id = Guid.NewGuid(), PlayerId = playerId };
+            _db.PlayerMindProfiles.Add(profile);
+        }
+
+        // Load recent events (last 50) for sidecar scoring
+        var recentEvents = await _db.PlayerBehaviorEvents
+            .AsNoTracking()
+            .Where(e => e.PlayerId == playerId)
+            .OrderByDescending(e => e.OccurredAt)
+            .Take(50)
+            .Select(e => new PlayerBehaviorEventDto(
+                e.EventType, e.EventSource, e.Category, e.Difficulty, e.Mode, null, e.OccurredAt))
+            .ToListAsync(ct);
+
+        if (profile.SidecarScoringEnabled)
+        {
+            try
+            {
+                var scores = await _sidecar.ScorePlayerAsync(new SidecarPlayerScoringRequest(
+                    playerId.ToString(),
+                    recentEvents,
+                    new SidecarPlayerSnapshotDto(
+                        profile.ConfidenceLevel,
+                        profile.ChurnRiskScore,
+                        profile.FrustrationRiskScore,
+                        profile.NotificationFatigueScore,
+                        profile.Archetype)), ct);
+
+                profile.ChurnRiskScore = scores.ChurnRiskScore;
+                profile.FrustrationRiskScore = scores.FrustrationRiskScore;
+                profile.ConfidenceLevel = scores.ConfidenceLevel;
+                profile.Archetype = scores.RecommendedArchetype;
+                profile.CategoryStrengthsJson = JsonSerializer.Serialize(scores.CategoryStrengths, _json);
+                profile.CategoryWeaknessesJson = JsonSerializer.Serialize(scores.CategoryWeaknesses, _json);
+                profile.SidecarScoresJson = JsonSerializer.Serialize(scores.Signals, _json);
+            }
+            catch
+            {
+                // Sidecar unavailable — retain existing profile scores
+            }
+        }
+
+        profile.LastCalculatedAt = DateTimeOffset.UtcNow;
+        profile.UpdatedAt = DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+
+        return MapToDto(profile);
+    }
+
+    private static PlayerMindProfileDto MapToDto(PlayerMindProfile p)
+    {
+        static Dictionary<string, decimal> ParseDecimalDict(string json)
+        {
+            try { return JsonSerializer.Deserialize<Dictionary<string, decimal>>(json, _json) ?? []; }
+            catch { return []; }
+        }
+
+        static Dictionary<string, object> ParseObjectDict(string json)
+        {
+            try { return JsonSerializer.Deserialize<Dictionary<string, object>>(json, _json) ?? []; }
+            catch { return []; }
+        }
+
+        return new PlayerMindProfileDto(
+            p.PlayerId, p.ConfidenceLevel, p.RiskTolerance,
+            p.PreferredPace, p.LearningStyle, p.CompetitivePreference, p.SocialPreference,
+            p.ChurnRiskScore, p.FrustrationRiskScore, p.RewardSensitivityScore,
+            p.StoreAffinityScore, p.NotificationFatigueScore, p.Archetype,
+            ParseDecimalDict(p.CategoryStrengthsJson),
+            ParseDecimalDict(p.CategoryWeaknessesJson),
+            ParseObjectDict(p.PreferenceJson),
+            ParseObjectDict(p.GuardrailJson),
+            p.PersonalizationEnabled,
+            p.SidecarScoringEnabled,
+            p.LastCalculatedAt);
+    }
+}

--- a/Tycoon.Backend.Domain/Personalization/PersonalizationRecommendation.cs
+++ b/Tycoon.Backend.Domain/Personalization/PersonalizationRecommendation.cs
@@ -1,0 +1,21 @@
+namespace Tycoon.Backend.Domain.Personalization;
+
+public sealed class PersonalizationRecommendation
+{
+    public Guid Id { get; set; }
+    public Guid PlayerId { get; set; }
+
+    public string RecommendationType { get; set; } = "";
+    public string Source { get; set; } = "backend";
+
+    public int Priority { get; set; }
+    public decimal Score { get; set; } = 0.50m;
+
+    public string PayloadJson { get; set; } = "{}";
+    public string GuardrailJson { get; set; } = "{}";
+
+    public DateTimeOffset? ExpiresAt { get; set; }
+    public DateTimeOffset? AcceptedAt { get; set; }
+    public DateTimeOffset? DismissedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Tycoon.Backend.Domain/Personalization/PersonalizationRule.cs
+++ b/Tycoon.Backend.Domain/Personalization/PersonalizationRule.cs
@@ -1,0 +1,12 @@
+namespace Tycoon.Backend.Domain.Personalization;
+
+public sealed class PersonalizationRule
+{
+    public Guid Id { get; set; }
+    public string RuleKey { get; set; } = "";
+    public string Description { get; set; } = "";
+    public bool IsEnabled { get; set; } = true;
+    public string RuleJson { get; set; } = "{}";
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Tycoon.Backend.Domain/Personalization/PlayerBehaviorEvent.cs
+++ b/Tycoon.Backend.Domain/Personalization/PlayerBehaviorEvent.cs
@@ -1,0 +1,19 @@
+namespace Tycoon.Backend.Domain.Personalization;
+
+public sealed class PlayerBehaviorEvent
+{
+    public Guid Id { get; set; }
+    public Guid PlayerId { get; set; }
+
+    public string EventType { get; set; } = "";
+    public string EventSource { get; set; } = "";
+
+    public string? Category { get; set; }
+    public string? Difficulty { get; set; }
+    public string? Mode { get; set; }
+
+    public string MetadataJson { get; set; } = "{}";
+
+    public DateTimeOffset OccurredAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset IngestedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Tycoon.Backend.Domain/Personalization/PlayerMindProfile.cs
+++ b/Tycoon.Backend.Domain/Personalization/PlayerMindProfile.cs
@@ -1,0 +1,36 @@
+namespace Tycoon.Backend.Domain.Personalization;
+
+public sealed class PlayerMindProfile
+{
+    public Guid Id { get; set; }
+    public Guid PlayerId { get; set; }
+
+    public decimal ConfidenceLevel { get; set; } = 0.50m;
+    public decimal RiskTolerance { get; set; } = 0.50m;
+
+    public string PreferredPace { get; set; } = "balanced";
+    public string LearningStyle { get; set; } = "mixed";
+    public string CompetitivePreference { get; set; } = "balanced";
+    public string SocialPreference { get; set; } = "solo";
+
+    public decimal ChurnRiskScore { get; set; }
+    public decimal FrustrationRiskScore { get; set; }
+    public decimal RewardSensitivityScore { get; set; } = 0.50m;
+    public decimal StoreAffinityScore { get; set; } = 0.50m;
+    public decimal NotificationFatigueScore { get; set; }
+
+    public string Archetype { get; set; } = "new_player";
+
+    public string CategoryStrengthsJson { get; set; } = "{}";
+    public string CategoryWeaknessesJson { get; set; } = "{}";
+    public string PreferenceJson { get; set; } = "{}";
+    public string GuardrailJson { get; set; } = "{}";
+    public string SidecarScoresJson { get; set; } = "{}";
+
+    public bool PersonalizationEnabled { get; set; } = true;
+    public bool SidecarScoringEnabled { get; set; } = true;
+
+    public DateTimeOffset? LastCalculatedAt { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -5,6 +5,7 @@ using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Application.Analytics.Models;
 using Tycoon.Backend.Domain.Abstractions;
 using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Domain.Personalization;
 using Tycoon.Backend.Infrastructure.Events;
 using Tycoon.Backend.Infrastructure.Persistence.Configurations;
 
@@ -107,6 +108,12 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<ModuleLesson> ModuleLessons => Set<ModuleLesson>();
         public DbSet<ModuleCompletion> ModuleCompletions => Set<ModuleCompletion>();
         public DbSet<StudySession> StudySessions => Set<StudySession>();
+
+        // Personalization
+        public DbSet<PlayerMindProfile> PlayerMindProfiles => Set<PlayerMindProfile>();
+        public DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents => Set<PlayerBehaviorEvent>();
+        public DbSet<PersonalizationRecommendation> PersonalizationRecommendations => Set<PersonalizationRecommendation>();
+        public DbSet<PersonalizationRule> PersonalizationRules => Set<PersonalizationRule>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationRecommendationConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationRecommendationConfiguration.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class PersonalizationRecommendationConfiguration : IEntityTypeConfiguration<PersonalizationRecommendation>
+{
+    public void Configure(EntityTypeBuilder<PersonalizationRecommendation> b)
+    {
+        b.ToTable("personalization_recommendations");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.PlayerId).HasColumnName("player_id");
+        b.Property(x => x.RecommendationType).HasColumnName("recommendation_type").HasMaxLength(128);
+        b.Property(x => x.Source).HasColumnName("source").HasMaxLength(64);
+        b.Property(x => x.Priority).HasColumnName("priority");
+        b.Property(x => x.Score).HasColumnName("score").HasPrecision(5, 2);
+        b.Property(x => x.PayloadJson).HasColumnName("payload_json").HasColumnType("jsonb");
+        b.Property(x => x.GuardrailJson).HasColumnName("guardrail_json").HasColumnType("jsonb");
+        b.Property(x => x.ExpiresAt).HasColumnName("expires_at");
+        b.Property(x => x.AcceptedAt).HasColumnName("accepted_at");
+        b.Property(x => x.DismissedAt).HasColumnName("dismissed_at");
+        b.Property(x => x.CreatedAt).HasColumnName("created_at");
+
+        b.HasIndex(x => new { x.PlayerId, x.CreatedAt })
+            .HasDatabaseName("ix_personalization_recommendations_player_created");
+        b.HasIndex(x => x.RecommendationType)
+            .HasDatabaseName("ix_personalization_recommendations_type");
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationRuleConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationRuleConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class PersonalizationRuleConfiguration : IEntityTypeConfiguration<PersonalizationRule>
+{
+    public void Configure(EntityTypeBuilder<PersonalizationRule> b)
+    {
+        b.ToTable("personalization_rules");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.RuleKey).HasColumnName("rule_key").HasMaxLength(256);
+        b.HasIndex(x => x.RuleKey).IsUnique().HasDatabaseName("ix_personalization_rules_rule_key");
+
+        b.Property(x => x.Description).HasColumnName("description").HasMaxLength(512);
+        b.Property(x => x.IsEnabled).HasColumnName("is_enabled");
+        b.Property(x => x.RuleJson).HasColumnName("rule_json").HasColumnType("jsonb");
+        b.Property(x => x.CreatedAt).HasColumnName("created_at");
+        b.Property(x => x.UpdatedAt).HasColumnName("updated_at");
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/PlayerBehaviorEventConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/PlayerBehaviorEventConfiguration.cs
@@ -1,0 +1,30 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class PlayerBehaviorEventConfiguration : IEntityTypeConfiguration<PlayerBehaviorEvent>
+{
+    public void Configure(EntityTypeBuilder<PlayerBehaviorEvent> b)
+    {
+        b.ToTable("player_behavior_events");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.PlayerId).HasColumnName("player_id");
+        b.Property(x => x.EventType).HasColumnName("event_type").HasMaxLength(128);
+        b.Property(x => x.EventSource).HasColumnName("event_source").HasMaxLength(128);
+        b.Property(x => x.Category).HasColumnName("category").HasMaxLength(128);
+        b.Property(x => x.Difficulty).HasColumnName("difficulty").HasMaxLength(64);
+        b.Property(x => x.Mode).HasColumnName("mode").HasMaxLength(64);
+        b.Property(x => x.MetadataJson).HasColumnName("metadata_json").HasColumnType("jsonb");
+        b.Property(x => x.OccurredAt).HasColumnName("occurred_at");
+        b.Property(x => x.IngestedAt).HasColumnName("ingested_at");
+
+        b.HasIndex(x => new { x.PlayerId, x.OccurredAt })
+            .HasDatabaseName("ix_player_behavior_events_player_time");
+        b.HasIndex(x => x.EventType).HasDatabaseName("ix_player_behavior_events_type");
+        b.HasIndex(x => x.EventSource).HasDatabaseName("ix_player_behavior_events_source");
+        b.HasIndex(x => x.Category).HasDatabaseName("ix_player_behavior_events_category");
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/PlayerMindProfileConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/PlayerMindProfileConfiguration.cs
@@ -1,0 +1,48 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class PlayerMindProfileConfiguration : IEntityTypeConfiguration<PlayerMindProfile>
+{
+    public void Configure(EntityTypeBuilder<PlayerMindProfile> b)
+    {
+        b.ToTable("player_mind_profiles");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.PlayerId).HasColumnName("player_id");
+        b.HasIndex(x => x.PlayerId).IsUnique();
+
+        b.Property(x => x.ConfidenceLevel).HasColumnName("confidence_level").HasPrecision(5, 2);
+        b.Property(x => x.RiskTolerance).HasColumnName("risk_tolerance").HasPrecision(5, 2);
+        b.Property(x => x.ChurnRiskScore).HasColumnName("churn_risk_score").HasPrecision(5, 2);
+        b.Property(x => x.FrustrationRiskScore).HasColumnName("frustration_risk_score").HasPrecision(5, 2);
+        b.Property(x => x.RewardSensitivityScore).HasColumnName("reward_sensitivity_score").HasPrecision(5, 2);
+        b.Property(x => x.StoreAffinityScore).HasColumnName("store_affinity_score").HasPrecision(5, 2);
+        b.Property(x => x.NotificationFatigueScore).HasColumnName("notification_fatigue_score").HasPrecision(5, 2);
+
+        b.Property(x => x.PreferredPace).HasColumnName("preferred_pace").HasMaxLength(64);
+        b.Property(x => x.LearningStyle).HasColumnName("learning_style").HasMaxLength(64);
+        b.Property(x => x.CompetitivePreference).HasColumnName("competitive_preference").HasMaxLength(64);
+        b.Property(x => x.SocialPreference).HasColumnName("social_preference").HasMaxLength(64);
+        b.Property(x => x.Archetype).HasColumnName("archetype").HasMaxLength(96);
+
+        b.Property(x => x.CategoryStrengthsJson).HasColumnName("category_strengths_json").HasColumnType("jsonb");
+        b.Property(x => x.CategoryWeaknessesJson).HasColumnName("category_weaknesses_json").HasColumnType("jsonb");
+        b.Property(x => x.PreferenceJson).HasColumnName("preference_json").HasColumnType("jsonb");
+        b.Property(x => x.GuardrailJson).HasColumnName("guardrail_json").HasColumnType("jsonb");
+        b.Property(x => x.SidecarScoresJson).HasColumnName("sidecar_scores_json").HasColumnType("jsonb");
+
+        b.Property(x => x.PersonalizationEnabled).HasColumnName("personalization_enabled");
+        b.Property(x => x.SidecarScoringEnabled).HasColumnName("sidecar_scoring_enabled");
+        b.Property(x => x.LastCalculatedAt).HasColumnName("last_calculated_at");
+        b.Property(x => x.CreatedAt).HasColumnName("created_at");
+        b.Property(x => x.UpdatedAt).HasColumnName("updated_at");
+
+        b.HasIndex(x => x.Archetype).HasDatabaseName("ix_player_mind_profiles_archetype");
+        b.HasIndex(x => x.ChurnRiskScore).HasDatabaseName("ix_player_mind_profiles_churn_risk");
+        b.HasIndex(x => x.FrustrationRiskScore).HasDatabaseName("ix_player_mind_profiles_frustration_risk");
+        b.HasIndex(x => x.UpdatedAt).HasDatabaseName("ix_player_mind_profiles_updated_at");
+    }
+}

--- a/Tycoon.Backend.Infrastructure/SidecarClient/PersonalizationSidecarClient.cs
+++ b/Tycoon.Backend.Infrastructure/SidecarClient/PersonalizationSidecarClient.cs
@@ -1,0 +1,119 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Infrastructure.SidecarClient;
+
+public sealed class PersonalizationSidecarClient : IPersonalizationSidecarClient
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private readonly HttpClient _http;
+
+    public PersonalizationSidecarClient(HttpClient http)
+    {
+        _http = http;
+    }
+
+    public async Task<SidecarPlayerScoresDto> ScorePlayerAsync(
+        SidecarPlayerScoringRequest request,
+        CancellationToken ct = default)
+    {
+        var payload = new
+        {
+            playerId = request.PlayerId,
+            recentEvents = request.RecentEvents.Select(e => new
+            {
+                eventType = e.EventType,
+                eventSource = e.EventSource,
+                category = e.Category,
+                difficulty = e.Difficulty,
+                mode = e.Mode,
+                metadata = e.Metadata ?? new Dictionary<string, object>()
+            }),
+            currentProfile = new
+            {
+                confidenceLevel = (double)request.CurrentProfile.ConfidenceLevel,
+                churnRiskScore = (double)request.CurrentProfile.ChurnRiskScore,
+                frustrationRiskScore = (double)request.CurrentProfile.FrustrationRiskScore,
+                notificationFatigueScore = (double)request.CurrentProfile.NotificationFatigueScore,
+                archetype = request.CurrentProfile.Archetype
+            }
+        };
+
+        var response = await _http.PostAsJsonAsync("/personalization/score-player", payload, _json, ct);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<SidecarScorePlayerResponse>(_json, ct)
+            ?? throw new InvalidOperationException("Sidecar returned empty score-player response.");
+
+        return new SidecarPlayerScoresDto(
+            (decimal)result.ChurnRiskScore,
+            (decimal)result.FrustrationRiskScore,
+            (decimal)result.ConfidenceLevel,
+            result.RecommendedArchetype,
+            result.CategoryStrengths.ToDictionary(kv => kv.Key, kv => (decimal)kv.Value),
+            result.CategoryWeaknesses.ToDictionary(kv => kv.Key, kv => (decimal)kv.Value),
+            result.Signals);
+    }
+
+    public async Task<IReadOnlyList<SidecarRecommendationCandidateDto>> GetRecommendationCandidatesAsync(
+        SidecarRecommendationRequest request,
+        CancellationToken ct = default)
+    {
+        var payload = new
+        {
+            playerId = request.PlayerId,
+            profile = new
+            {
+                confidenceLevel = (double)request.Profile.ConfidenceLevel,
+                churnRiskScore = (double)request.Profile.ChurnRiskScore,
+                frustrationRiskScore = (double)request.Profile.FrustrationRiskScore,
+                notificationFatigueScore = (double)request.Profile.NotificationFatigueScore,
+                archetype = request.Profile.Archetype
+            },
+            recentEvents = request.RecentEvents.Select(e => new
+            {
+                eventType = e.EventType,
+                eventSource = e.EventSource,
+                category = e.Category,
+                difficulty = e.Difficulty,
+                mode = e.Mode,
+                metadata = e.Metadata ?? new Dictionary<string, object>()
+            })
+        };
+
+        var response = await _http.PostAsJsonAsync("/personalization/recommendation-candidates", payload, _json, ct);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<SidecarCandidatesResponse>(_json, ct)
+            ?? throw new InvalidOperationException("Sidecar returned empty recommendation-candidates response.");
+
+        return result.Candidates.Select(c => new SidecarRecommendationCandidateDto(
+            c.Type,
+            c.TargetId,
+            (decimal)c.Score,
+            c.Reason,
+            c.Payload)).ToList();
+    }
+
+    // Local response shapes (not shared — internal to this client)
+    private sealed record SidecarScorePlayerResponse(
+        double ChurnRiskScore,
+        double FrustrationRiskScore,
+        double ConfidenceLevel,
+        string RecommendedArchetype,
+        Dictionary<string, double> CategoryStrengths,
+        Dictionary<string, double> CategoryWeaknesses,
+        Dictionary<string, object> Signals);
+
+    private sealed record SidecarCandidatesResponse(List<SidecarCandidateItem> Candidates);
+
+    private sealed record SidecarCandidateItem(
+        string Type,
+        string? TargetId,
+        double Score,
+        string Reason,
+        Dictionary<string, object> Payload);
+}

--- a/Tycoon.Backend.Migrations/Migrations/20260429100000_AddPersonalizationTables.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260429100000_AddPersonalizationTables.cs
@@ -1,0 +1,179 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tycoon.Backend.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalizationTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "player_mind_profiles",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    player_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    confidence_level = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.50m),
+                    risk_tolerance = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.50m),
+                    preferred_pace = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "balanced"),
+                    learning_style = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "mixed"),
+                    competitive_preference = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "balanced"),
+                    social_preference = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "solo"),
+                    churn_risk_score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.00m),
+                    frustration_risk_score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.00m),
+                    reward_sensitivity_score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.50m),
+                    store_affinity_score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.50m),
+                    notification_fatigue_score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.00m),
+                    archetype = table.Column<string>(type: "character varying(96)", maxLength: 96, nullable: false, defaultValue: "new_player"),
+                    category_strengths_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    category_weaknesses_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    preference_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    guardrail_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    sidecar_scores_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    personalization_enabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    sidecar_scoring_enabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    last_calculated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_player_mind_profiles", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_mind_profiles_player_id",
+                table: "player_mind_profiles",
+                column: "player_id",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_mind_profiles_archetype",
+                table: "player_mind_profiles",
+                column: "archetype");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_mind_profiles_churn_risk",
+                table: "player_mind_profiles",
+                column: "churn_risk_score");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_mind_profiles_frustration_risk",
+                table: "player_mind_profiles",
+                column: "frustration_risk_score");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_mind_profiles_updated_at",
+                table: "player_mind_profiles",
+                column: "updated_at");
+
+            migrationBuilder.CreateTable(
+                name: "player_behavior_events",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    player_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    event_type = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    event_source = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    category = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    difficulty = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    mode = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    metadata_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    occurred_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    ingested_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_player_behavior_events", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_behavior_events_player_time",
+                table: "player_behavior_events",
+                columns: new[] { "player_id", "occurred_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_behavior_events_type",
+                table: "player_behavior_events",
+                column: "event_type");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_behavior_events_source",
+                table: "player_behavior_events",
+                column: "event_source");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_player_behavior_events_category",
+                table: "player_behavior_events",
+                column: "category");
+
+            migrationBuilder.CreateTable(
+                name: "personalization_recommendations",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    player_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    recommendation_type = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "backend"),
+                    priority = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    score = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 0.50m),
+                    payload_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    guardrail_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    expires_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    accepted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    dismissed_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_personalization_recommendations", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_recommendations_player_created",
+                table: "personalization_recommendations",
+                columns: new[] { "player_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_recommendations_type",
+                table: "personalization_recommendations",
+                column: "recommendation_type");
+
+            migrationBuilder.CreateTable(
+                name: "personalization_rules",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    rule_key = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    description = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false, defaultValue: ""),
+                    is_enabled = table.Column<bool>(type: "boolean", nullable: false, defaultValue: true),
+                    rule_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_personalization_rules", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_rules_rule_key",
+                table: "personalization_rules",
+                column: "rule_key",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "personalization_rules");
+            migrationBuilder.DropTable(name: "personalization_recommendations");
+            migrationBuilder.DropTable(name: "player_behavior_events");
+            migrationBuilder.DropTable(name: "player_mind_profiles");
+        }
+    }
+}

--- a/Tycoon.Shared.Contracts/Dtos/PersonalizationDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/PersonalizationDtos.cs
@@ -1,0 +1,140 @@
+namespace Tycoon.Shared.Contracts.Dtos;
+
+public sealed record PlayerMindProfileDto(
+    Guid PlayerId,
+    decimal ConfidenceLevel,
+    decimal RiskTolerance,
+    string PreferredPace,
+    string LearningStyle,
+    string CompetitivePreference,
+    string SocialPreference,
+    decimal ChurnRiskScore,
+    decimal FrustrationRiskScore,
+    decimal RewardSensitivityScore,
+    decimal StoreAffinityScore,
+    decimal NotificationFatigueScore,
+    string Archetype,
+    Dictionary<string, decimal> CategoryStrengths,
+    Dictionary<string, decimal> CategoryWeaknesses,
+    Dictionary<string, object> Preferences,
+    Dictionary<string, object> Guardrails,
+    bool PersonalizationEnabled,
+    bool SidecarScoringEnabled,
+    DateTimeOffset? LastCalculatedAt
+);
+
+public sealed record PlayerBehaviorEventDto(
+    string EventType,
+    string EventSource,
+    string? Category,
+    string? Difficulty,
+    string? Mode,
+    Dictionary<string, object>? Metadata,
+    DateTimeOffset? OccurredAt
+);
+
+public sealed record PlayerRecommendationDto(
+    Guid Id,
+    string Type,
+    string Source,
+    int Priority,
+    decimal Score,
+    Dictionary<string, object> Payload,
+    Dictionary<string, object> Guardrails,
+    DateTimeOffset? ExpiresAt
+);
+
+public sealed record CoachBriefDto(
+    string Title,
+    string Message,
+    string RecommendedAction,
+    string? TargetRoute,
+    string Tone
+);
+
+public sealed record PlayerHomePersonalizationDto(
+    Guid PlayerId,
+    string RecommendedMode,
+    string? RecommendedCategory,
+    string? RecommendedDifficulty,
+    IReadOnlyList<PlayerRecommendationDto> Recommendations,
+    CoachBriefDto? CoachBrief,
+    Dictionary<string, object> Guardrails
+);
+
+// Sidecar client DTOs
+public sealed record SidecarPlayerScoringRequest(
+    string PlayerId,
+    IReadOnlyList<PlayerBehaviorEventDto> RecentEvents,
+    SidecarPlayerSnapshotDto CurrentProfile
+);
+
+public sealed record SidecarPlayerSnapshotDto(
+    decimal ConfidenceLevel,
+    decimal ChurnRiskScore,
+    decimal FrustrationRiskScore,
+    decimal NotificationFatigueScore,
+    string Archetype
+);
+
+public sealed record SidecarPlayerScoresDto(
+    decimal ChurnRiskScore,
+    decimal FrustrationRiskScore,
+    decimal ConfidenceLevel,
+    string RecommendedArchetype,
+    Dictionary<string, decimal> CategoryStrengths,
+    Dictionary<string, decimal> CategoryWeaknesses,
+    Dictionary<string, object> Signals
+);
+
+public sealed record SidecarRecommendationRequest(
+    string PlayerId,
+    SidecarPlayerSnapshotDto Profile,
+    IReadOnlyList<PlayerBehaviorEventDto> RecentEvents
+);
+
+public sealed record SidecarRecommendationCandidateDto(
+    string Type,
+    string? TargetId,
+    decimal Score,
+    string Reason,
+    Dictionary<string, object> Payload
+);
+
+// Guardrail types
+public sealed record PersonalizationCandidateDto(
+    string Type,
+    decimal Score,
+    Dictionary<string, object> Payload
+);
+
+public sealed record PersonalizationGuardrailResult(
+    bool Allowed,
+    string? BlockReason,
+    Dictionary<string, object> AppliedRules
+);
+
+// Admin DTOs
+public sealed record PersonalizationSummaryDto(
+    Dictionary<string, int> ArchetypeCounts,
+    int HighChurnRiskCount,
+    int HighFrustrationRiskCount,
+    int TotalProfiles,
+    DateTimeOffset GeneratedAt
+);
+
+public sealed record PersonalizationRuleDto(
+    Guid Id,
+    string RuleKey,
+    string Description,
+    bool IsEnabled,
+    Dictionary<string, object> Rule,
+    DateTimeOffset UpdatedAt
+);
+
+public sealed record UpdatePersonalizationRuleRequest(
+    bool? IsEnabled,
+    Dictionary<string, object>? Rule
+);
+
+public sealed record CoachFeedbackRequest(string BriefId, string Feedback);

--- a/Tycoon.Sidecar/app/main.py
+++ b/Tycoon.Sidecar/app/main.py
@@ -10,7 +10,7 @@ from pymongo.errors import OperationFailure
 
 from app.config import settings
 from app.grpc_client import GrpcClientManager
-from app.routers import analytics, ml, utilities, webhooks
+from app.routers import analytics, ml, utilities, webhooks, personalization as personalization_router
 from app.routes import auth as auth_routes, config as config_routes
 
 # Normalize .NET-style log level names (Information, Warning, Critical) to Python equivalents
@@ -94,12 +94,13 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-app.include_router(ml.router,               prefix="/ml",        tags=["ML"])
-app.include_router(analytics.router,        prefix="/analytics", tags=["Analytics"])
-app.include_router(webhooks.router,         prefix="/webhooks",  tags=["Webhooks"])
-app.include_router(utilities.router,        prefix="/utilities", tags=["Utilities"])
-app.include_router(auth_routes.router,      prefix="/auth",      tags=["Auth"])
-app.include_router(config_routes.router,    prefix="/config",    tags=["Config"])
+app.include_router(ml.router,                          prefix="/ml",             tags=["ML"])
+app.include_router(analytics.router,                   prefix="/analytics",      tags=["Analytics"])
+app.include_router(webhooks.router,                    prefix="/webhooks",       tags=["Webhooks"])
+app.include_router(utilities.router,                   prefix="/utilities",      tags=["Utilities"])
+app.include_router(auth_routes.router,                 prefix="/auth",           tags=["Auth"])
+app.include_router(config_routes.router,               prefix="/config",         tags=["Config"])
+app.include_router(personalization_router.router,      tags=["Personalization"])
 
 
 @app.get("/health", tags=["Health"])

--- a/Tycoon.Sidecar/app/routers/personalization.py
+++ b/Tycoon.Sidecar/app/routers/personalization.py
@@ -1,0 +1,117 @@
+from fastapi import APIRouter
+from app.schemas.personalization import (
+    ScorePlayerRequest,
+    ScorePlayerResponse,
+    RecommendationCandidateRequest,
+    RecommendationCandidateResponse,
+    RecommendationCandidate,
+)
+
+router = APIRouter(prefix="/personalization", tags=["personalization"])
+
+
+@router.post("/score-player", response_model=ScorePlayerResponse)
+async def score_player(request: ScorePlayerRequest) -> ScorePlayerResponse:
+    incorrect = 0
+    total_answers = 0
+    slow_answers = 0
+    category_misses: dict[str, int] = {}
+
+    for event in request.recentEvents:
+        if event.eventType == "question_answered":
+            total_answers += 1
+            correct = bool(event.metadata.get("correct", False))
+            answer_time_ms = int(event.metadata.get("answerTimeMs", 0))
+
+            if not correct:
+                incorrect += 1
+                if event.category:
+                    category_misses[event.category] = category_misses.get(event.category, 0) + 1
+
+            if answer_time_ms > 9000:
+                slow_answers += 1
+
+    miss_rate = incorrect / total_answers if total_answers else 0.0
+    slow_rate = slow_answers / total_answers if total_answers else 0.0
+
+    frustration = min(1.0, (miss_rate * 0.65) + (slow_rate * 0.35))
+    confidence = max(0.0, min(1.0, 1.0 - frustration))
+
+    if total_answers < 5:
+        archetype = "new_player"
+    elif frustration >= 0.70:
+        archetype = "confidence_builder"
+    elif miss_rate < 0.20 and total_answers >= 20:
+        archetype = "mastery_path"
+    else:
+        archetype = request.currentProfile.archetype
+
+    weaknesses = {
+        category: min(1.0, misses / max(1, total_answers))
+        for category, misses in category_misses.items()
+    }
+
+    churn_risk = min(
+        1.0,
+        request.currentProfile.churnRiskScore + (frustration * 0.10),
+    )
+
+    return ScorePlayerResponse(
+        churnRiskScore=round(churn_risk, 4),
+        frustrationRiskScore=round(frustration, 4),
+        confidenceLevel=round(confidence, 4),
+        recommendedArchetype=archetype,
+        categoryStrengths={},
+        categoryWeaknesses=weaknesses,
+        signals={
+            "missRate": round(miss_rate, 4),
+            "slowRate": round(slow_rate, 4),
+            "totalAnswers": total_answers,
+        },
+    )
+
+
+@router.post("/recommendation-candidates", response_model=RecommendationCandidateResponse)
+async def recommendation_candidates(
+    request: RecommendationCandidateRequest,
+) -> RecommendationCandidateResponse:
+    candidates: list[RecommendationCandidate] = []
+
+    if request.profile.frustrationRiskScore >= 0.65:
+        candidates.append(RecommendationCandidate(
+            type="learning_module",
+            targetId="confidence-warmup",
+            score=0.92,
+            reason="Player has elevated frustration risk; recommend low-pressure learning.",
+            payload={"tone": "encouraging", "difficultyStrategy": "warmup"},
+        ))
+
+    if request.profile.churnRiskScore >= 0.60:
+        candidates.append(RecommendationCandidate(
+            type="mission",
+            targetId=None,
+            score=0.85,
+            reason="Player shows churn risk; a quick mission can re-engage them.",
+            payload={"tone": "encouraging", "missionArchetype": "comeback_player"},
+        ))
+
+    if request.profile.notificationFatigueScore < 0.50:
+        candidates.append(RecommendationCandidate(
+            type="coach_tip",
+            targetId=None,
+            score=0.70,
+            reason="Player can receive one helpful coach recommendation.",
+            payload={"tone": "supportive"},
+        ))
+
+    if request.profile.archetype in ("streak_seeker", "risk_taker", "social_challenger"):
+        candidates.append(RecommendationCandidate(
+            type="event",
+            targetId=None,
+            score=0.75,
+            reason="Competitive player archetype benefits from event recommendations.",
+            payload={"tone": "competitive"},
+        ))
+
+    candidates.sort(key=lambda c: c.score, reverse=True)
+    return RecommendationCandidateResponse(candidates=candidates)

--- a/Tycoon.Sidecar/app/schemas/personalization.py
+++ b/Tycoon.Sidecar/app/schemas/personalization.py
@@ -1,0 +1,53 @@
+from typing import Any, Dict, List, Optional
+from pydantic import BaseModel, Field
+
+
+class BehaviorEvent(BaseModel):
+    eventType: str
+    eventSource: str
+    category: Optional[str] = None
+    difficulty: Optional[str] = None
+    mode: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class PlayerProfileSnapshot(BaseModel):
+    confidenceLevel: float = 0.5
+    churnRiskScore: float = 0.0
+    frustrationRiskScore: float = 0.0
+    notificationFatigueScore: float = 0.0
+    archetype: str = "new_player"
+
+
+class ScorePlayerRequest(BaseModel):
+    playerId: str
+    recentEvents: List[BehaviorEvent] = Field(default_factory=list)
+    currentProfile: PlayerProfileSnapshot
+
+
+class ScorePlayerResponse(BaseModel):
+    churnRiskScore: float
+    frustrationRiskScore: float
+    confidenceLevel: float
+    recommendedArchetype: str
+    categoryStrengths: Dict[str, float] = Field(default_factory=dict)
+    categoryWeaknesses: Dict[str, float] = Field(default_factory=dict)
+    signals: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RecommendationCandidate(BaseModel):
+    type: str
+    targetId: Optional[str] = None
+    score: float
+    reason: str
+    payload: Dict[str, Any] = Field(default_factory=dict)
+
+
+class RecommendationCandidateRequest(BaseModel):
+    playerId: str
+    profile: PlayerProfileSnapshot
+    recentEvents: List[BehaviorEvent] = Field(default_factory=list)
+
+
+class RecommendationCandidateResponse(BaseModel):
+    candidates: List[RecommendationCandidate]


### PR DESCRIPTION
PR 1 — DB + EF models
- Domain entities: PlayerMindProfile, PlayerBehaviorEvent, PersonalizationRecommendation, PersonalizationRule (Tycoon.Backend.Domain/Personalization/)
- EF configs for all 4 entities with JSONB columns, CHECK constraint indexes, and composite keys
- Migration 20260429100000_AddPersonalizationTables: 4 tables, 11 indexes
- IAppDb + AppDb extended with 4 new DbSet properties

PR 2 — Application services
- PersonalizationDtos.cs: PlayerMindProfileDto, PlayerBehaviorEventDto, PlayerRecommendationDto, PlayerHomePersonalizationDto, CoachBriefDto, sidecar request/response types, guardrail types, admin DTOs
- IPlayerMindProfileService / PlayerMindProfileService: GetOrCreateAsync, RecordEventAsync, RecalculateAsync (with sidecar scoring + local fallback)
- IPersonalizationService / PersonalizationService: GetHomeAsync, GetRecommendationsAsync, Accept/Dismiss (guardrail-filtered, persisted recommendations)
- IPersonalizationGuardrailService / PersonalizationGuardrailService: store_offer suppression, notification fatigue limit, ranked fairness lock, opt-out enforcement
- IPersonalizationSidecarClient interface
- All services registered in DependencyInjection.cs

PR 3 — API endpoints
- PersonalizationEndpoints: GET/POST /personalization/profile/{id}, GET /personalization/home/{id}, GET /personalization/recommendations, POST accept/dismiss
- CoachEndpoints: GET /coach/{id}/daily-brief, POST /coach/{id}/feedback
- Both registered in Program.cs with RequireAuthorization()

PR 4 — FastAPI sidecar
- app/schemas/personalization.py: Pydantic models for all request/response types
- app/routers/personalization.py: POST /personalization/score-player (miss-rate + slow-rate frustration scoring, archetype classification), POST /personalization/recommendation-candidates (4 candidate types)
- Router registered in main.py

PR 5 — .NET SidecarClient
- PersonalizationSidecarClient: typed HttpClient calling both sidecar routes; decimal↔float conversion; EnsureSuccessStatusCode so callers can catch and fall back
- Registered via AddHttpClient<> with 5s timeout in Program.cs; base URL from SidecarPersonalization:BaseUrl config

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2