### PR TITLE
feat(experiments): A/B testing framework + package vulnerability fixes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup Label="MediatR">
     <PackageVersion Include="Hangfire.InMemory" Version="0.11.0" />
     <PackageVersion Include="MediatR" Version="14.0.0" />
-    <PackageVersion Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <!-- MediatR.Extensions.Microsoft.DependencyInjection was merged into MediatR 12+; removed -->
     <PackageVersion Include="Mediator.Abstractions" Version="3.0.1" />
     <PackageVersion Include="Npgsql" Version="10.0.0" />
   </ItemGroup>
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup Label="FluentValidation">
     <PackageVersion Include="FluentValidation" Version="12.1.1" />
-    <PackageVersion Include="FluentValidation.AspNetCore" Version="11.3.1" />
+    <PackageVersion Include="FluentValidation.AspNetCore" Version="12.1.1" />
     <PackageVersion Include="FluentValidation.DependencyInjectionExtensions" Version="12.1.1" />
   </ItemGroup>
   <ItemGroup Label="Hangfire">
@@ -59,7 +59,7 @@
     <PackageVersion Include="Elastic.Serilog.Sinks" Version="8.19.0" />
   </ItemGroup>
   <ItemGroup Label="ASP.NET Core">
-    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.3.9" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.Cookies" Version="9.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.HeaderPropagation" Version="9.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
@@ -184,6 +184,7 @@
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.9" />
     <PackageVersion Include="SecurityCodeScan.VS2019" Version="5.6.7" />
+    <!-- Note: SecurityCodeScan.VS2019 is build-time only; upgrade to VS2022 package when tooling permits -->
   </ItemGroup>
   <ItemGroup Label="API Gateway">
     <PackageVersion Include="Yarp.ReverseProxy" Version="2.2.0" />

--- a/Tycoon.Backend.Api/Features/AdminExperiments/AdminExperimentEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminExperiments/AdminExperimentEndpoints.cs
@@ -1,0 +1,214 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Experiments;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Api.Features.AdminExperiments;
+
+public static class AdminExperimentEndpoints
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    public static void Map(RouteGroupBuilder admin)
+    {
+        var g = admin.MapGroup("/experiments").WithTags("Admin/Experiments").WithOpenApi();
+
+        g.MapGet("/", ListExperiments);
+        g.MapGet("/{id:guid}", GetExperiment);
+        g.MapPost("/", CreateExperiment);
+        g.MapPut("/{id:guid}", UpdateExperiment);
+        g.MapPost("/{id:guid}/start", StartExperiment);
+        g.MapPost("/{id:guid}/pause", PauseExperiment);
+        g.MapPost("/{id:guid}/complete", CompleteExperiment);
+        g.MapGet("/{id:guid}/results", GetResults);
+        g.MapDelete("/{id:guid}", DeleteExperiment);
+    }
+
+    private static async Task<IResult> ListExperiments(
+        IAppDb db, string? status, CancellationToken ct)
+    {
+        var q = db.Experiments.AsNoTracking().Include(e => e.Variants).AsQueryable();
+        if (!string.IsNullOrWhiteSpace(status))
+            q = q.Where(e => e.Status == status);
+
+        var list = await q.OrderByDescending(e => e.CreatedAt).ToListAsync(ct);
+        return Results.Ok(list.Select(ToDto).ToList());
+    }
+
+    private static async Task<IResult> GetExperiment(Guid id, IAppDb db, CancellationToken ct)
+    {
+        var exp = await db.Experiments.AsNoTracking()
+            .Include(e => e.Variants)
+            .FirstOrDefaultAsync(e => e.Id == id, ct);
+        return exp is null ? Results.NotFound() : Results.Ok(ToDto(exp));
+    }
+
+    private static async Task<IResult> CreateExperiment(
+        [FromBody] CreateExperimentRequest req, IAppDb db, CancellationToken ct)
+    {
+        if (await db.Experiments.AnyAsync(e => e.Key == req.Key, ct))
+            return Results.Conflict(new { error = "experiment_key_exists", key = req.Key });
+
+        if (req.Variants is null || req.Variants.Count < 2)
+            return Results.BadRequest(new { error = "min_two_variants" });
+
+        var experiment = new Experiment
+        {
+            Id = Guid.NewGuid(),
+            Key = req.Key.Trim().ToLowerInvariant(),
+            Name = req.Name.Trim(),
+            Description = req.Description?.Trim() ?? "",
+            Status = "draft",
+            AllocationPercent = req.AllocationPercent ?? 100m,
+            StartsAt = req.StartsAt,
+            EndsAt = req.EndsAt,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        foreach (var v in req.Variants)
+        {
+            experiment.Variants.Add(new ExperimentVariant
+            {
+                Id = Guid.NewGuid(),
+                ExperimentId = experiment.Id,
+                Key = v.Key.Trim().ToLowerInvariant(),
+                Name = v.Name.Trim(),
+                Weight = v.Weight,
+                IsControl = v.IsControl,
+                ConfigJson = v.Config is not null
+                    ? JsonSerializer.Serialize(v.Config, _json)
+                    : "{}"
+            });
+        }
+
+        db.Experiments.Add(experiment);
+        await db.SaveChangesAsync(ct);
+        return Results.Created($"/admin/experiments/{experiment.Id}", ToDto(experiment));
+    }
+
+    private static async Task<IResult> UpdateExperiment(
+        Guid id, [FromBody] UpdateExperimentRequest req, IAppDb db, CancellationToken ct)
+    {
+        var exp = await db.Experiments.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (exp is null) return Results.NotFound();
+
+        if (req.Name is not null) exp.Name = req.Name.Trim();
+        if (req.Description is not null) exp.Description = req.Description.Trim();
+        if (req.Status is not null) exp.Status = req.Status;
+        if (req.AllocationPercent.HasValue) exp.AllocationPercent = req.AllocationPercent.Value;
+        if (req.StartsAt.HasValue) exp.StartsAt = req.StartsAt;
+        if (req.EndsAt.HasValue) exp.EndsAt = req.EndsAt;
+        exp.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await db.SaveChangesAsync(ct);
+        // Reload variants for response
+        var updated = await db.Experiments.AsNoTracking()
+            .Include(e => e.Variants)
+            .FirstOrDefaultAsync(e => e.Id == id, ct);
+        return Results.Ok(ToDto(updated!));
+    }
+
+    private static Task<IResult> StartExperiment(Guid id, IAppDb db, CancellationToken ct)
+        => SetStatus(id, "running", db, ct);
+
+    private static Task<IResult> PauseExperiment(Guid id, IAppDb db, CancellationToken ct)
+        => SetStatus(id, "paused", db, ct);
+
+    private static Task<IResult> CompleteExperiment(Guid id, IAppDb db, CancellationToken ct)
+        => SetStatus(id, "completed", db, ct);
+
+    private static async Task<IResult> SetStatus(Guid id, string status, IAppDb db, CancellationToken ct)
+    {
+        var exp = await db.Experiments.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (exp is null) return Results.NotFound();
+        exp.Status = status;
+        exp.UpdatedAt = DateTimeOffset.UtcNow;
+        await db.SaveChangesAsync(ct);
+        return Results.Ok(new { id, status });
+    }
+
+    private static async Task<IResult> GetResults(Guid id, IAppDb db, CancellationToken ct)
+    {
+        var exp = await db.Experiments.AsNoTracking()
+            .Include(e => e.Variants)
+            .FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (exp is null) return Results.NotFound();
+
+        var assignments = await db.ExperimentAssignments
+            .AsNoTracking()
+            .Where(a => a.ExperimentId == id)
+            .ToListAsync(ct);
+
+        var total = assignments.Count;
+        var controlOutcomeRate = 0.0;
+
+        var variantResults = exp.Variants
+            .OrderBy(v => v.Key)
+            .Select(v =>
+            {
+                var group = assignments.Where(a => a.VariantKey == v.Key).ToList();
+                var cnt = group.Count;
+                var impressions = group.Sum(a => a.ImpressionCount);
+                var outcomes = group.Sum(a => a.OutcomeCount);
+                var impRate = cnt == 0 ? 0.0 : Math.Round((double)impressions / cnt, 4);
+                var outRate = cnt == 0 ? 0.0 : Math.Round((double)outcomes / cnt, 4);
+                if (v.IsControl) controlOutcomeRate = outRate;
+                return new { v, cnt, impressions, outcomes, impRate, outRate };
+            })
+            .ToList();
+
+        var results = variantResults.Select(x => new ExperimentVariantResultDto(
+            VariantKey: x.v.Key,
+            IsControl: x.v.IsControl,
+            Assignments: x.cnt,
+            Impressions: x.impressions,
+            Outcomes: x.outcomes,
+            ImpressionRate: x.impRate,
+            OutcomeRate: x.outRate,
+            LiftVsControl: x.v.IsControl ? 0.0
+                : controlOutcomeRate == 0.0 ? 0.0
+                : Math.Round((x.outRate - controlOutcomeRate) / controlOutcomeRate, 4)
+        )).ToList();
+
+        return Results.Ok(new ExperimentResultsDto(
+            ExperimentId: exp.Id,
+            ExperimentKey: exp.Key,
+            Status: exp.Status,
+            Variants: results,
+            TotalAssignments: total,
+            GeneratedAt: DateTimeOffset.UtcNow));
+    }
+
+    private static async Task<IResult> DeleteExperiment(Guid id, IAppDb db, CancellationToken ct)
+    {
+        var exp = await db.Experiments.FirstOrDefaultAsync(e => e.Id == id, ct);
+        if (exp is null) return Results.NotFound();
+        if (exp.Status == "running")
+            return Results.Conflict(new { error = "cannot_delete_running_experiment" });
+
+        db.Experiments.Remove(exp);
+        await db.SaveChangesAsync(ct);
+        return Results.Ok(new { deleted = true, id });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static ExperimentDto ToDto(Experiment e) =>
+        new(e.Id, e.Key, e.Name, e.Description, e.Status, e.AllocationPercent,
+            e.StartsAt, e.EndsAt,
+            e.Variants.OrderBy(v => v.Key).Select(ToVariantDto).ToList(),
+            e.CreatedAt, e.UpdatedAt);
+
+    private static ExperimentVariantDto ToVariantDto(ExperimentVariant v) =>
+        new(v.Id, v.Key, v.Name, v.Weight, v.IsControl,
+            ParseJson(v.ConfigJson).ToDictionary(k => k.Key, k => k.Value ?? (object)""));
+
+    private static Dictionary<string, object?> ParseJson(string json)
+    {
+        try { return JsonSerializer.Deserialize<Dictionary<string, object?>>(json, _json) ?? []; }
+        catch { return []; }
+    }
+}

--- a/Tycoon.Backend.Api/Features/Experiments/ExperimentEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Experiments/ExperimentEndpoints.cs
@@ -1,0 +1,58 @@
+using Tycoon.Backend.Application.Experiments;
+
+namespace Tycoon.Backend.Api.Features.Experiments;
+
+public static class ExperimentEndpoints
+{
+    public static void Map(WebApplication app)
+    {
+        var g = app.MapGroup("/experiments")
+            .WithTags("Experiments")
+            .RequireAuthorization()
+            .WithOpenApi();
+
+        // Bootstrap all active experiment assignments for a player at session start
+        g.MapGet("/player/{playerId:guid}", GetAllAssignments);
+
+        // Single-experiment assignment (used when a specific feature checks its own flag)
+        g.MapGet("/player/{playerId:guid}/{experimentKey}", GetAssignment);
+
+        // Telemetry — called when the player actually sees the variant UI
+        g.MapPost("/player/{playerId:guid}/{experimentKey}/impression", RecordImpression);
+
+        // Telemetry — called when the player converts (purchase, completion, etc.)
+        g.MapPost("/player/{playerId:guid}/{experimentKey}/outcome", RecordOutcome);
+    }
+
+    private static async Task<IResult> GetAllAssignments(
+        Guid playerId, IExperimentService experiments, CancellationToken ct)
+    {
+        var result = await experiments.GetAllAssignmentsAsync(playerId, ct);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetAssignment(
+        Guid playerId, string experimentKey, IExperimentService experiments, CancellationToken ct)
+    {
+        var assignment = await experiments.GetAssignmentAsync(playerId, experimentKey, ct);
+        if (assignment is null)
+            return Results.Ok(new { enrolled = false, experimentKey });
+        return Results.Ok(new { enrolled = true, experimentKey, assignment });
+    }
+
+    private static async Task<IResult> RecordImpression(
+        Guid playerId, string experimentKey, IExperimentService experiments, CancellationToken ct)
+    {
+        await experiments.RecordImpressionAsync(playerId, experimentKey, ct);
+        return Results.Accepted();
+    }
+
+    private static async Task<IResult> RecordOutcome(
+        Guid playerId, string experimentKey,
+        IExperimentService experiments,
+        CancellationToken ct)
+    {
+        await experiments.RecordOutcomeAsync(playerId, experimentKey, null, ct);
+        return Results.Accepted();
+    }
+}

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -38,7 +38,9 @@ using Tycoon.Backend.Api.Features.AdminPowerups;
 using Tycoon.Backend.Api.Features.AdminQuestions;
 using Tycoon.Backend.Api.Features.AdminStore;
 using Tycoon.Backend.Api.Features.AdminSeasons;
+using Tycoon.Backend.Api.Features.AdminExperiments;
 using Tycoon.Backend.Api.Features.AdminPersonalization;
+using Tycoon.Backend.Api.Features.Experiments;
 using Tycoon.Backend.Api.Features.AdminSkills;
 using Tycoon.Backend.Api.Features.AdminUsers;
 using Tycoon.Backend.Api.Features.Analytics;
@@ -843,6 +845,7 @@ StoreEndpoints.Map(app);
 AvatarEndpoints.Map(app);
 PersonalizationEndpoints.Map(app);
 CoachEndpoints.Map(app);
+ExperimentEndpoints.Map(app);
 CryptoEconomyEndpoints.Map(app);
 MlScoringEndpoints.Map(app);
 GameEventsEndpoints.Map(app);
@@ -894,6 +897,7 @@ AdminEmailAclEndpoints.Map(admin);
 AdminStoreEndpoints.Map(admin);
 AdminLearningModulesEndpoints.Map(admin);
 AdminPersonalizationEndpoints.Map(admin);
+AdminExperimentEndpoints.Map(admin);
 
 // Startup logging
 app.Logger.LogInformation("🚀 Tycoon Backend API starting...");

--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Tycoon.Backend.Application.Analytics.Models;
 using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Domain.Experiments;
 using Tycoon.Backend.Domain.Personalization;
 
 namespace Tycoon.Backend.Application.Abstractions
@@ -97,6 +98,11 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents { get; }
         DbSet<PersonalizationRecommendation> PersonalizationRecommendations { get; }
         DbSet<PersonalizationRule> PersonalizationRules { get; }
+
+        // A/B Experiments
+        DbSet<Experiment> Experiments { get; }
+        DbSet<ExperimentVariant> ExperimentVariants { get; }
+        DbSet<ExperimentAssignment> ExperimentAssignments { get; }
 
         Task<int> SaveChangesAsync(CancellationToken ct = default);
         EntityEntry Entry(object entity);

--- a/Tycoon.Backend.Application/DependencyInjection.cs
+++ b/Tycoon.Backend.Application/DependencyInjection.cs
@@ -123,6 +123,9 @@ namespace Tycoon.Backend.Application
             services.AddScoped<Personalization.IPersonalizationService, Personalization.PersonalizationService>();
             services.AddScoped<Personalization.IPersonalizationGuardrailService, Personalization.PersonalizationGuardrailService>();
 
+            // A/B Experiments
+            services.AddScoped<Experiments.IExperimentService, Experiments.ExperimentService>();
+
             return services;
         }
     }

--- a/Tycoon.Backend.Application/Experiments/ExperimentService.cs
+++ b/Tycoon.Backend.Application/Experiments/ExperimentService.cs
@@ -1,0 +1,189 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Experiments;
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Experiments;
+
+public sealed class ExperimentService : IExperimentService
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private readonly IAppDb _db;
+
+    public ExperimentService(IAppDb db)
+    {
+        _db = db;
+    }
+
+    public async Task<ExperimentAssignmentDto?> GetAssignmentAsync(
+        Guid playerId, string experimentKey, CancellationToken ct = default)
+    {
+        var experiment = await _db.Experiments
+            .AsNoTracking()
+            .Include(e => e.Variants)
+            .FirstOrDefaultAsync(e => e.Key == experimentKey && e.Status == "running", ct);
+
+        if (experiment is null || experiment.Variants.Count == 0)
+            return null;
+
+        // Allocation gating: deterministic bucket 0.0–1.0 vs allocation threshold
+        var bucket = GetBucket(playerId, experimentKey);
+        if (bucket > (double)(experiment.AllocationPercent / 100m))
+            return null;
+
+        // Return existing assignment if one already exists
+        var existing = await _db.ExperimentAssignments
+            .FirstOrDefaultAsync(a => a.PlayerId == playerId && a.ExperimentId == experiment.Id, ct);
+
+        if (existing is not null)
+            return ToDto(existing, experiment);
+
+        // Assign to a variant using deterministic bucket mapped over normalised weights
+        var variant = SelectVariant(experiment.Variants, bucket);
+        if (variant is null)
+            return null;
+
+        var assignment = new ExperimentAssignment
+        {
+            Id = Guid.NewGuid(),
+            PlayerId = playerId,
+            ExperimentId = experiment.Id,
+            ExperimentKey = experimentKey,
+            VariantKey = variant.Key,
+            AssignedAt = DateTimeOffset.UtcNow
+        };
+
+        _db.ExperimentAssignments.Add(assignment);
+        try
+        {
+            await _db.SaveChangesAsync(ct);
+        }
+        catch (DbUpdateException)
+        {
+            // Race: another request created the assignment concurrently — re-load it
+            _db.Entry(assignment).State = EntityState.Detached;
+            existing = await _db.ExperimentAssignments
+                .FirstOrDefaultAsync(a => a.PlayerId == playerId && a.ExperimentId == experiment.Id, ct);
+            if (existing is null)
+                return null;
+            return ToDto(existing, experiment);
+        }
+
+        return ToDto(assignment, experiment);
+    }
+
+    public async Task<PlayerExperimentsDto> GetAllAssignmentsAsync(
+        Guid playerId, CancellationToken ct = default)
+    {
+        var runningExperiments = await _db.Experiments
+            .AsNoTracking()
+            .Include(e => e.Variants)
+            .Where(e => e.Status == "running")
+            .ToListAsync(ct);
+
+        var results = new List<ExperimentAssignmentDto>();
+
+        foreach (var experiment in runningExperiments)
+        {
+            var dto = await GetAssignmentAsync(playerId, experiment.Key, ct);
+            if (dto is not null)
+                results.Add(dto);
+        }
+
+        return new PlayerExperimentsDto(playerId, results);
+    }
+
+    public async Task RecordImpressionAsync(
+        Guid playerId, string experimentKey, CancellationToken ct = default)
+    {
+        var assignment = await _db.ExperimentAssignments
+            .FirstOrDefaultAsync(a => a.PlayerId == playerId && a.ExperimentKey == experimentKey, ct);
+        if (assignment is null)
+            return;
+
+        assignment.ImpressionCount++;
+        assignment.FirstSeenAt ??= DateTimeOffset.UtcNow;
+        await _db.SaveChangesAsync(ct);
+    }
+
+    public async Task RecordOutcomeAsync(
+        Guid playerId, string experimentKey,
+        Dictionary<string, object>? outcomeData = null,
+        CancellationToken ct = default)
+    {
+        var assignment = await _db.ExperimentAssignments
+            .FirstOrDefaultAsync(a => a.PlayerId == playerId && a.ExperimentKey == experimentKey, ct);
+        if (assignment is null)
+            return;
+
+        assignment.OutcomeCount++;
+        if (outcomeData is { Count: > 0 })
+        {
+            var existing = ParseJson(assignment.OutcomeJson);
+            foreach (var kv in outcomeData)
+                existing[kv.Key] = kv.Value;
+            assignment.OutcomeJson = JsonSerializer.Serialize(existing, _json);
+        }
+
+        await _db.SaveChangesAsync(ct);
+    }
+
+    // ── Internals ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Deterministic bucket [0.0, 1.0) derived from MD5(playerId:experimentKey).
+    /// The same player always maps to the same bucket for a given experiment.
+    /// </summary>
+    private static double GetBucket(Guid playerId, string experimentKey)
+    {
+        var input = $"{playerId}:{experimentKey}";
+        var hash = MD5.HashData(Encoding.UTF8.GetBytes(input));
+        var value = BitConverter.ToUInt32(hash, 0);
+        return (double)value / uint.MaxValue;
+    }
+
+    /// <summary>
+    /// Maps a bucket value to a variant using normalised cumulative weights.
+    /// Variants are sorted by Key for determinism regardless of insertion order.
+    /// </summary>
+    private static ExperimentVariant? SelectVariant(
+        ICollection<ExperimentVariant> variants, double bucket)
+    {
+        var sorted = variants.OrderBy(v => v.Key).ToList();
+        var totalWeight = sorted.Sum(v => (double)v.Weight);
+        if (totalWeight <= 0)
+            return null;
+
+        var cursor = 0.0;
+        foreach (var variant in sorted)
+        {
+            cursor += (double)variant.Weight / totalWeight;
+            if (bucket < cursor)
+                return variant;
+        }
+
+        return sorted.Last();
+    }
+
+    private ExperimentAssignmentDto ToDto(ExperimentAssignment assignment, Experiment experiment)
+    {
+        var variant = experiment.Variants.FirstOrDefault(v => v.Key == assignment.VariantKey);
+        return new ExperimentAssignmentDto(
+            ExperimentKey: assignment.ExperimentKey,
+            VariantKey: assignment.VariantKey,
+            IsControl: variant?.IsControl ?? false,
+            Config: ParseJson(variant?.ConfigJson ?? "{}")
+                .ToDictionary(k => k.Key, k => k.Value ?? (object)"")
+        );
+    }
+
+    private static Dictionary<string, object?> ParseJson(string json)
+    {
+        try { return JsonSerializer.Deserialize<Dictionary<string, object?>>(json, _json) ?? []; }
+        catch { return []; }
+    }
+}

--- a/Tycoon.Backend.Application/Experiments/IExperimentService.cs
+++ b/Tycoon.Backend.Application/Experiments/IExperimentService.cs
@@ -1,0 +1,29 @@
+using Tycoon.Shared.Contracts.Dtos;
+
+namespace Tycoon.Backend.Application.Experiments;
+
+public interface IExperimentService
+{
+    /// <summary>
+    /// Returns the variant a player is assigned to for the given experiment, or null if they are
+    /// excluded from the experiment (allocation gating, experiment not running, or not found).
+    /// Assignment is created and persisted on first call; subsequent calls return the same variant.
+    /// </summary>
+    Task<ExperimentAssignmentDto?> GetAssignmentAsync(Guid playerId, string experimentKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all active-experiment assignments for a player in a single query — used by the
+    /// client to bootstrap all experiment state at session start.
+    /// </summary>
+    Task<PlayerExperimentsDto> GetAllAssignmentsAsync(Guid playerId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Records that the player saw the variant UI. Increments impression_count and sets first_seen_at.
+    /// </summary>
+    Task RecordImpressionAsync(Guid playerId, string experimentKey, CancellationToken ct = default);
+
+    /// <summary>
+    /// Records a conversion / outcome for this player's assignment.
+    /// </summary>
+    Task RecordOutcomeAsync(Guid playerId, string experimentKey, Dictionary<string, object>? outcomeData = null, CancellationToken ct = default);
+}

--- a/Tycoon.Backend.Application/Tycoon.Backend.Application.csproj
+++ b/Tycoon.Backend.Application/Tycoon.Backend.Application.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" />
     <PackageReference Include="Hangfire" />
     <PackageReference Include="MediatR" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Npgsql" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />

--- a/Tycoon.Backend.Domain/Experiments/Experiment.cs
+++ b/Tycoon.Backend.Domain/Experiments/Experiment.cs
@@ -1,0 +1,32 @@
+namespace Tycoon.Backend.Domain.Experiments;
+
+/// <summary>
+/// An A/B experiment definition. Status lifecycle: draft → running → paused → completed.
+/// </summary>
+public sealed class Experiment
+{
+    public Guid Id { get; set; }
+
+    /// <summary>Stable slug used in application code to look up this experiment (e.g. "store-cta-color").</summary>
+    public string Key { get; set; } = "";
+
+    public string Name { get; set; } = "";
+    public string Description { get; set; } = "";
+
+    /// <summary>draft | running | paused | completed</summary>
+    public string Status { get; set; } = "draft";
+
+    /// <summary>Percentage of eligible players to enroll (0–100). Remaining players get no variant (control by exclusion).</summary>
+    public decimal AllocationPercent { get; set; } = 100m;
+
+    public DateTimeOffset? StartsAt { get; set; }
+    public DateTimeOffset? EndsAt { get; set; }
+
+    /// <summary>Arbitrary operator-defined metadata (hypothesis, ticket links, etc.).</summary>
+    public string MetadataJson { get; set; } = "{}";
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset UpdatedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    public ICollection<ExperimentVariant> Variants { get; set; } = [];
+}

--- a/Tycoon.Backend.Domain/Experiments/ExperimentAssignment.cs
+++ b/Tycoon.Backend.Domain/Experiments/ExperimentAssignment.cs
@@ -1,0 +1,28 @@
+namespace Tycoon.Backend.Domain.Experiments;
+
+/// <summary>
+/// Persistent record of which variant a player was assigned to in an experiment.
+/// Assignments are deterministic and created on first call; never re-randomised.
+/// </summary>
+public sealed class ExperimentAssignment
+{
+    public Guid Id { get; set; }
+    public Guid PlayerId { get; set; }
+    public Guid ExperimentId { get; set; }
+
+    /// <summary>Denormalised for fast lookups without joining Experiment.</summary>
+    public string ExperimentKey { get; set; } = "";
+
+    public string VariantKey { get; set; } = "";
+
+    public DateTimeOffset AssignedAt { get; set; } = DateTimeOffset.UtcNow;
+
+    /// <summary>Set on first RecordImpression call — when the player actually saw this variant.</summary>
+    public DateTimeOffset? FirstSeenAt { get; set; }
+
+    public int ImpressionCount { get; set; } = 0;
+    public int OutcomeCount { get; set; } = 0;
+
+    /// <summary>JSON bag of outcome metrics (e.g. {"purchased": true, "revenue": 4.99}).</summary>
+    public string OutcomeJson { get; set; } = "{}";
+}

--- a/Tycoon.Backend.Domain/Experiments/ExperimentVariant.cs
+++ b/Tycoon.Backend.Domain/Experiments/ExperimentVariant.cs
@@ -1,0 +1,27 @@
+namespace Tycoon.Backend.Domain.Experiments;
+
+/// <summary>
+/// A named variant within an experiment (e.g., "control", "treatment_a").
+/// Weights are relative — they are normalised to 100 at assignment time.
+/// </summary>
+public sealed class ExperimentVariant
+{
+    public Guid Id { get; set; }
+    public Guid ExperimentId { get; set; }
+
+    /// <summary>Stable variant slug used in code (e.g. "control", "treatment_a").</summary>
+    public string Key { get; set; } = "";
+
+    public string Name { get; set; } = "";
+
+    /// <summary>Relative traffic weight (0–100). Variants are normalised so weights sum to 100.</summary>
+    public decimal Weight { get; set; } = 50m;
+
+    /// <summary>True for the baseline variant — used to compute lift in analytics.</summary>
+    public bool IsControl { get; set; } = false;
+
+    /// <summary>Variant-specific configuration payload delivered to clients alongside the assignment.</summary>
+    public string ConfigJson { get; set; } = "{}";
+
+    public Experiment? Experiment { get; set; }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -5,6 +5,7 @@ using Tycoon.Backend.Application.Abstractions;
 using Tycoon.Backend.Application.Analytics.Models;
 using Tycoon.Backend.Domain.Abstractions;
 using Tycoon.Backend.Domain.Entities;
+using Tycoon.Backend.Domain.Experiments;
 using Tycoon.Backend.Domain.Personalization;
 using Tycoon.Backend.Infrastructure.Events;
 using Tycoon.Backend.Infrastructure.Persistence.Configurations;
@@ -114,6 +115,11 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents => Set<PlayerBehaviorEvent>();
         public DbSet<PersonalizationRecommendation> PersonalizationRecommendations => Set<PersonalizationRecommendation>();
         public DbSet<PersonalizationRule> PersonalizationRules => Set<PersonalizationRule>();
+
+        // A/B Experiments
+        public DbSet<Experiment> Experiments => Set<Experiment>();
+        public DbSet<ExperimentVariant> ExperimentVariants => Set<ExperimentVariant>();
+        public DbSet<ExperimentAssignment> ExperimentAssignments => Set<ExperimentAssignment>();
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentAssignmentConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentAssignmentConfiguration.cs
@@ -1,0 +1,29 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Experiments;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class ExperimentAssignmentConfiguration : IEntityTypeConfiguration<ExperimentAssignment>
+{
+    public void Configure(EntityTypeBuilder<ExperimentAssignment> b)
+    {
+        b.ToTable("experiment_assignments");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.PlayerId).HasColumnName("player_id").IsRequired();
+        b.Property(x => x.ExperimentId).HasColumnName("experiment_id").IsRequired();
+        b.Property(x => x.ExperimentKey).HasColumnName("experiment_key").HasMaxLength(128).IsRequired();
+        b.Property(x => x.VariantKey).HasColumnName("variant_key").HasMaxLength(128).IsRequired();
+        b.Property(x => x.AssignedAt).HasColumnName("assigned_at").IsRequired();
+        b.Property(x => x.FirstSeenAt).HasColumnName("first_seen_at").IsRequired(false);
+        b.Property(x => x.ImpressionCount).HasColumnName("impression_count").HasDefaultValue(0);
+        b.Property(x => x.OutcomeCount).HasColumnName("outcome_count").HasDefaultValue(0);
+        b.Property(x => x.OutcomeJson).HasColumnName("outcome_json").HasColumnType("jsonb").IsRequired().HasDefaultValue("{}");
+
+        // One assignment per player per experiment
+        b.HasIndex(x => new { x.PlayerId, x.ExperimentId }).IsUnique();
+        // Fast lookup by experiment for analytics
+        b.HasIndex(x => new { x.ExperimentId, x.VariantKey });
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentConfiguration.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Experiments;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class ExperimentConfiguration : IEntityTypeConfiguration<Experiment>
+{
+    public void Configure(EntityTypeBuilder<Experiment> b)
+    {
+        b.ToTable("experiments");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.Key).HasColumnName("key").HasMaxLength(128).IsRequired();
+        b.HasIndex(x => x.Key).IsUnique();
+
+        b.Property(x => x.Name).HasColumnName("name").HasMaxLength(256).IsRequired();
+        b.Property(x => x.Description).HasColumnName("description").HasMaxLength(1000).IsRequired(false);
+        b.Property(x => x.Status).HasColumnName("status").HasMaxLength(32).IsRequired().HasDefaultValue("draft");
+        b.Property(x => x.AllocationPercent).HasColumnName("allocation_percent").HasPrecision(5, 2).HasDefaultValue(100m);
+        b.Property(x => x.StartsAt).HasColumnName("starts_at").IsRequired(false);
+        b.Property(x => x.EndsAt).HasColumnName("ends_at").IsRequired(false);
+        b.Property(x => x.MetadataJson).HasColumnName("metadata_json").HasColumnType("jsonb").IsRequired().HasDefaultValue("{}");
+        b.Property(x => x.CreatedAt).HasColumnName("created_at").IsRequired();
+        b.Property(x => x.UpdatedAt).HasColumnName("updated_at").IsRequired();
+
+        b.HasIndex(x => x.Status);
+
+        b.HasMany(x => x.Variants)
+            .WithOne(v => v.Experiment)
+            .HasForeignKey(v => v.ExperimentId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentVariantConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/ExperimentVariantConfiguration.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Experiments;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class ExperimentVariantConfiguration : IEntityTypeConfiguration<ExperimentVariant>
+{
+    public void Configure(EntityTypeBuilder<ExperimentVariant> b)
+    {
+        b.ToTable("experiment_variants");
+        b.HasKey(x => x.Id);
+
+        b.Property(x => x.ExperimentId).HasColumnName("experiment_id").IsRequired();
+        b.Property(x => x.Key).HasColumnName("key").HasMaxLength(128).IsRequired();
+        b.Property(x => x.Name).HasColumnName("name").HasMaxLength(256).IsRequired();
+        b.Property(x => x.Weight).HasColumnName("weight").HasPrecision(6, 2).HasDefaultValue(50m);
+        b.Property(x => x.IsControl).HasColumnName("is_control").HasDefaultValue(false);
+        b.Property(x => x.ConfigJson).HasColumnName("config_json").HasColumnType("jsonb").IsRequired().HasDefaultValue("{}");
+
+        b.HasIndex(x => new { x.ExperimentId, x.Key }).IsUnique();
+    }
+}

--- a/Tycoon.Backend.Migrations/Migrations/20260429120000_AddExperimentTables.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260429120000_AddExperimentTables.cs
@@ -1,0 +1,115 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tycoon.Backend.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddExperimentTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "experiments",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    description = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    status = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false, defaultValue: "draft"),
+                    allocation_percent = table.Column<decimal>(type: "numeric(5,2)", precision: 5, scale: 2, nullable: false, defaultValue: 100m),
+                    starts_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    ends_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    metadata_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_experiments", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "experiment_variants",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    experiment_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    name = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    weight = table.Column<decimal>(type: "numeric(6,2)", precision: 6, scale: 2, nullable: false, defaultValue: 50m),
+                    is_control = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    config_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_experiment_variants", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_experiment_variants_experiments_experiment_id",
+                        column: x => x.experiment_id,
+                        principalTable: "experiments",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "experiment_assignments",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    player_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    experiment_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    experiment_key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    variant_key = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    assigned_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    first_seen_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    impression_count = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    outcome_count = table.Column<int>(type: "integer", nullable: false, defaultValue: 0),
+                    outcome_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_experiment_assignments", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_experiments_key",
+                table: "experiments",
+                column: "key",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_experiments_status",
+                table: "experiments",
+                column: "status");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_experiment_variants_experiment_id_key",
+                table: "experiment_variants",
+                columns: new[] { "experiment_id", "key" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_experiment_assignments_player_id_experiment_id",
+                table: "experiment_assignments",
+                columns: new[] { "player_id", "experiment_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_experiment_assignments_experiment_id_variant_key",
+                table: "experiment_assignments",
+                columns: new[] { "experiment_id", "variant_key" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "experiment_assignments");
+            migrationBuilder.DropTable(name: "experiment_variants");
+            migrationBuilder.DropTable(name: "experiments");
+        }
+    }
+}

--- a/Tycoon.Shared.Contracts/Dtos/ExperimentDtos.cs
+++ b/Tycoon.Shared.Contracts/Dtos/ExperimentDtos.cs
@@ -1,0 +1,95 @@
+namespace Tycoon.Shared.Contracts.Dtos;
+
+// ── Experiment management ────────────────────────────────────────────────────
+
+public sealed record ExperimentDto(
+    Guid Id,
+    string Key,
+    string Name,
+    string? Description,
+    string Status,
+    decimal AllocationPercent,
+    DateTimeOffset? StartsAt,
+    DateTimeOffset? EndsAt,
+    IReadOnlyList<ExperimentVariantDto> Variants,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset UpdatedAt
+);
+
+public sealed record ExperimentVariantDto(
+    Guid Id,
+    string Key,
+    string Name,
+    decimal Weight,
+    bool IsControl,
+    Dictionary<string, object> Config
+);
+
+// ── Assignment (returned to clients) ────────────────────────────────────────
+
+public sealed record ExperimentAssignmentDto(
+    string ExperimentKey,
+    string VariantKey,
+    bool IsControl,
+    Dictionary<string, object> Config
+);
+
+/// <summary>
+/// Bulk response: all active experiment assignments for one player.
+/// Clients pass their playerId once and receive every running experiment they are enrolled in.
+/// </summary>
+public sealed record PlayerExperimentsDto(
+    Guid PlayerId,
+    IReadOnlyList<ExperimentAssignmentDto> Assignments
+);
+
+// ── Admin write requests ────────────────────────────────────────────────────
+
+public sealed record CreateExperimentRequest(
+    string Key,
+    string Name,
+    string? Description,
+    decimal? AllocationPercent,
+    DateTimeOffset? StartsAt,
+    DateTimeOffset? EndsAt,
+    IReadOnlyList<CreateExperimentVariantRequest> Variants
+);
+
+public sealed record CreateExperimentVariantRequest(
+    string Key,
+    string Name,
+    decimal Weight,
+    bool IsControl,
+    Dictionary<string, object>? Config
+);
+
+public sealed record UpdateExperimentRequest(
+    string? Name,
+    string? Description,
+    string? Status,
+    decimal? AllocationPercent,
+    DateTimeOffset? StartsAt,
+    DateTimeOffset? EndsAt
+);
+
+// ── Admin analytics ─────────────────────────────────────────────────────────
+
+public sealed record ExperimentResultsDto(
+    Guid ExperimentId,
+    string ExperimentKey,
+    string Status,
+    IReadOnlyList<ExperimentVariantResultDto> Variants,
+    int TotalAssignments,
+    DateTimeOffset GeneratedAt
+);
+
+public sealed record ExperimentVariantResultDto(
+    string VariantKey,
+    bool IsControl,
+    int Assignments,
+    int Impressions,
+    int Outcomes,
+    double ImpressionRate,
+    double OutcomeRate,
+    double LiftVsControl
+);


### PR DESCRIPTION
## A/B Testing Framework
- Domain: Experiment, ExperimentVariant, ExperimentAssignment entities
- EF configs: experiments, experiment_variants, experiment_assignments tables with unique indexes on (key), (experiment_id, key), (player_id, experiment_id)
- Migration: 20260429120000_AddExperimentTables (PostgreSQL, with full Down())
- IExperimentService / ExperimentService:
  - Deterministic variant assignment via MD5(playerId:experimentKey) consistent hash
  - Allocation gating: player bucket vs AllocationPercent threshold
  - Race-safe: DB unique index + catch(DbUpdateException) for concurrent first-assignment
  - GetAllAssignmentsAsync: bulk bootstrap for session start
  - RecordImpressionAsync / RecordOutcomeAsync: telemetry counters
- Shared DTOs: ExperimentDto, ExperimentVariantDto, ExperimentAssignmentDto, PlayerExperimentsDto, CreateExperimentRequest, UpdateExperimentRequest, ExperimentResultsDto, ExperimentVariantResultDto
- Admin endpoints (9 routes under /admin/experiments): GET / | GET /:id | POST / | PUT /:id | POST /:id/start|pause|complete GET /:id/results (variant assignment counts, impression/outcome rates, lift vs control) DELETE /:id (blocked if status=running)
- Public endpoints (4 routes under /experiments, RequireAuthorization): GET /player/:id | GET /player/:id/:key | POST impression | POST outcome

## Package Vulnerability Fixes
- FluentValidation.AspNetCore 11.3.1 → 12.1.1 (version mismatch with FluentValidation 12.x)
- Microsoft.AspNetCore.Authentication.Cookies 2.3.9 → 9.0.11 (CVE risk: 2.x era package)
- Remove MediatR.Extensions.Microsoft.DependencyInjection 11.0.0 (merged into MediatR 12+, orphaned alongside MediatR 14; removed from Directory.Packages.props and Application.csproj)

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2