### PR TITLE
Fix Microsoft.OpenApi 2.0 namespace and API breaking changes

### DIFF
--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/CorrelationIdHeaderOperationTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/CorrelationIdHeaderOperationTransformer.cs
@@ -1,6 +1,6 @@
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace Tycoon.Shared.OpenApi.AspnetOpenApi;
 
@@ -28,7 +28,7 @@ public class CorrelationIdHeaderOperationTransformer : IOpenApiOperationTransfor
                 Schema = new OpenApiSchema
                 {
                     Type = "string",
-                    Example = new OpenApiString("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
+                    Example = JsonValue.Create("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
                 },
             }
         );

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/EnumSchemaTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/EnumSchemaTransformer.cs
@@ -1,6 +1,6 @@
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace Tycoon.Shared.OpenApi.AspnetOpenApi;
 
@@ -22,7 +22,7 @@ public class EnumSchemaTransformer : IOpenApiSchemaTransformer
         schema.Enum.Clear();
 
         // Add only string representations of the enum values
-        Enum.GetNames(enumType).ToList().ForEach(name => schema.Enum.Add(new OpenApiString(name)));
+        Enum.GetNames(enumType).ToList().ForEach(name => schema.Enum.Add(JsonValue.Create(name)!));
 
         // Set the schema type explicitly to "string"
         schema.Type = "string";

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiDefaultValuesOperationTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiDefaultValuesOperationTransformer.cs
@@ -1,8 +1,8 @@
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.OpenApi.Models;
-using Swashbuckle.AspNetCore.SwaggerGen;
+using Microsoft.OpenApi;
 
 namespace Tycoon.Shared.OpenApi.AspnetOpenApi;
 
@@ -61,7 +61,7 @@ public class OpenApiDefaultValuesOperationTransformer : IOpenApiOperationTransfo
             {
                 // REF: https://github.com/Microsoft/aspnet-api-versioning/issues/429#issuecomment-605402330
                 var json = JsonSerializer.Serialize(description.DefaultValue, modelMetadata.ModelType);
-                parameter.Schema.Default = OpenApiAnyFactory.CreateFromJson(json);
+                parameter.Schema.Default = JsonNode.Parse(json);
             }
 
             parameter.Required |= description.IsRequired;

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiVersioningDocumentTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiVersioningDocumentTransformer.cs
@@ -3,7 +3,7 @@ using Asp.Versioning.ApiExplorer;
 using Microsoft.AspNetCore.OpenApi;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace Tycoon.Shared.OpenApi.AspnetOpenApi;
 

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/SecuritySchemeDocumentTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/SecuritySchemeDocumentTransformer.cs
@@ -1,5 +1,5 @@
 using Microsoft.AspNetCore.OpenApi;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 
 namespace Tycoon.Shared.OpenApi.AspnetOpenApi;
 

--- a/Tycoon.Shared/OpenApi/Swashbuckle/ConfigureSwaggerGenVersioningOptions.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/ConfigureSwaggerGenVersioningOptions.cs
@@ -3,7 +3,7 @@ using Asp.Versioning.ApiExplorer;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Tycoon.Shared.OpenApi.Swashbuckle;

--- a/Tycoon.Shared/OpenApi/Swashbuckle/CorrelationIdHeaderOperationFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/CorrelationIdHeaderOperationFilter.cs
@@ -1,5 +1,5 @@
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Tycoon.Shared.OpenApi.Swashbuckle;
@@ -23,7 +23,7 @@ public class CorrelationIdHeaderOperationFilter : IOperationFilter
                 Schema = new OpenApiSchema
                 {
                     Type = "string",
-                    Example = new OpenApiString("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
+                    Example = JsonValue.Create("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
                 },
             }
         );

--- a/Tycoon.Shared/OpenApi/Swashbuckle/EnumSchemaFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/EnumSchemaFilter.cs
@@ -1,5 +1,5 @@
-using Microsoft.OpenApi.Any;
-using Microsoft.OpenApi.Models;
+using System.Text.Json.Nodes;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Tycoon.Shared.OpenApi.Swashbuckle;
@@ -8,21 +8,16 @@ namespace Tycoon.Shared.OpenApi.Swashbuckle;
 // `SchemaFilter` is used to customize `schemas` in the OpenAPI document.
 public class EnumSchemaFilter : ISchemaFilter
 {
-    public void Apply(OpenApiSchema schema, SchemaFilterContext context)
+    // Swashbuckle 10 / Microsoft.OpenApi 2.0: parameter changed to IOpenApiSchema.
+    // Cast to the concrete OpenApiSchema to access mutable Enum list.
+    public void Apply(IOpenApiSchema schema, SchemaFilterContext context)
     {
-        var enumType = context.Type;
+        if (!context.Type.IsEnum) return;
+        if (schema is not OpenApiSchema concreteSchema) return;
 
-        // Check if the type is an enum
-        if (!enumType.IsEnum)
-            return;
-
-        // Clear the default enum values
-        schema.Enum.Clear();
-
-        // Add only string representations of the enum values
-        Enum.GetNames(enumType).ToList().ForEach(name => schema.Enum.Add(new OpenApiString(name)));
-
-        // Set the schema type explicitly to "string"
-        schema.Type = "string";
+        concreteSchema.Enum.Clear();
+        Enum.GetNames(context.Type).ToList()
+            .ForEach(name => concreteSchema.Enum.Add(JsonValue.Create(name)!));
+        concreteSchema.Type = "string";
     }
 }

--- a/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Tycoon.Shared.Core.Extensions.ServiceCollectionsExtensions;
 using Swashbuckle.AspNetCore.SwaggerGen;
 

--- a/Tycoon.Shared/OpenApi/Swashbuckle/SwaggerDefaultValuesOperationFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/SwaggerDefaultValuesOperationFilter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Text.Json;
+using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
-using Microsoft.OpenApi.Models;
+using Microsoft.OpenApi;
 using Swashbuckle.AspNetCore.SwaggerGen;
 
 namespace Tycoon.Shared.OpenApi.Swashbuckle;
@@ -63,7 +64,7 @@ public class SwaggerDefaultValuesOperationFilter : IOperationFilter
             {
                 // REF: https://github.com/Microsoft/aspnet-api-versioning/issues/429#issuecomment-605402330
                 var json = JsonSerializer.Serialize(description.DefaultValue, modelMetadata.ModelType);
-                parameter.Schema.Default = OpenApiAnyFactory.CreateFromJson(json);
+                parameter.Schema.Default = JsonNode.Parse(json);
             }
 
             parameter.Required |= description.IsRequired;


### PR DESCRIPTION
Microsoft.OpenApi 2.0 (ships with Microsoft.AspNetCore.OpenApi 10.0.7) has three breaking changes affecting all OpenAPI filter/transformer files:

1. Microsoft.OpenApi.Models namespace removed — all types (OpenApiDocument, OpenApiOperation, OpenApiSchema, OpenApiInfo, OpenApiParameter, OpenApiSecurityScheme, ParameterLocation, ReferenceType, etc.) moved to the root Microsoft.OpenApi namespace.

2. Microsoft.OpenApi.Any namespace removed — OpenApiString and IOpenApiAny eliminated; replaced by System.Text.Json.Nodes.JsonNode / JsonValue.

3. OpenApiAnyFactory.CreateFromJson() removed — replaced by JsonNode.Parse().

Additional Swashbuckle 10 change:
   ISchemaFilter.Apply first parameter changed from OpenApiSchema to IOpenApiSchema (read-only interface); cast to OpenApiSchema inside EnumSchemaFilter to retain mutation capability.

Files changed (10):
  Swashbuckle/ConfigureSwaggerGenVersioningOptions.cs         — (1)
  Swashbuckle/Extensions/DependencyInjectionExtensions.cs     — (1)
  Swashbuckle/SwaggerDefaultValuesOperationFilter.cs          — (1)(3)
  Swashbuckle/CorrelationIdHeaderOperationFilter.cs           — (1)(2)
  Swashbuckle/EnumSchemaFilter.cs                             — (1)(2) + sig fix
  AspnetOpenApi/SecuritySchemeDocumentTransformer.cs          — (1)
  AspnetOpenApi/OpenApiVersioningDocumentTransformer.cs       — (1)
  AspnetOpenApi/OpenApiDefaultValuesOperationTransformer.cs   — (1)(3)
  AspnetOpenApi/CorrelationIdHeaderOperationTransformer.cs    — (1)(2)
  AspnetOpenApi/EnumSchemaTransformer.cs                      — (1)(2)

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2