### PR TITLE
Fix remaining Microsoft.OpenApi 2.0 and OTel EF Core breaking changes

### DIFF
--- a/Tycoon.Shared/Observability/DependencyInjectionExtensions.cs
+++ b/Tycoon.Shared/Observability/DependencyInjectionExtensions.cs
@@ -158,10 +158,7 @@ public static class DependencyInjectionExtensions
                     {
                         instrumentationOptions.RecordException = true;
                     })
-                    .AddEntityFrameworkCoreInstrumentation(instrumentationOptions =>
-                    {
-                        instrumentationOptions.SetDbStatementForText = true;
-                    })
+                    .AddEntityFrameworkCoreInstrumentation()
                     .AddSource(MassTransit.Logging.DiagnosticHeaders.DefaultListenerName)
                     .AddNpgsql()
                     // `AddSource` for adding custom activity sources

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/CorrelationIdHeaderOperationTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/CorrelationIdHeaderOperationTransformer.cs
@@ -15,7 +15,7 @@ public class CorrelationIdHeaderOperationTransformer : IOpenApiOperationTransfor
         CancellationToken cancellationToken
     )
     {
-        operation.Parameters ??= new List<OpenApiParameter>();
+        operation.Parameters ??= new List<IOpenApiParameter>();
 
         // Add the Correlation ID header to the operation parameters
         operation.Parameters.Add(
@@ -27,7 +27,7 @@ public class CorrelationIdHeaderOperationTransformer : IOpenApiOperationTransfor
                 Required = false, // Set to true if the header is mandatory
                 Schema = new OpenApiSchema
                 {
-                    Type = "string",
+                    Type = JsonSchemaType.String,
                     Example = JsonValue.Create("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
                 },
             }

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/EnumSchemaTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/EnumSchemaTransformer.cs
@@ -25,7 +25,7 @@ public class EnumSchemaTransformer : IOpenApiSchemaTransformer
         Enum.GetNames(enumType).ToList().ForEach(name => schema.Enum.Add(JsonValue.Create(name)!));
 
         // Set the schema type explicitly to "string"
-        schema.Type = "string";
+        schema.Type = JsonSchemaType.String;
 
         return Task.CompletedTask;
     }

--- a/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiDefaultValuesOperationTransformer.cs
+++ b/Tycoon.Shared/OpenApi/AspnetOpenApi/OpenApiDefaultValuesOperationTransformer.cs
@@ -16,10 +16,12 @@ public class OpenApiDefaultValuesOperationTransformer : IOpenApiOperationTransfo
     )
     {
         var apiDescription = context.Description;
-        var actionDescriptor = apiDescription.ActionDescriptor;
-        var endpointMetadata = actionDescriptor.EndpointMetadata;
 
-        openApiOperation.Deprecated |= apiDescription.IsDeprecated();
+        // IsDeprecated() extension was removed in Swashbuckle 10 — check endpoint metadata directly.
+        var isDeprecated = apiDescription.ActionDescriptor.EndpointMetadata
+            .OfType<ObsoleteAttribute>()
+            .Any();
+        openApiOperation.Deprecated |= isDeprecated;
 
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1752#issue-663991077
         foreach (var responseType in context.Description.SupportedResponseTypes)
@@ -44,27 +46,29 @@ public class OpenApiDefaultValuesOperationTransformer : IOpenApiOperationTransfo
 
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/412
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/413
+        // OpenAPI 2.0: Parameters is IList<IOpenApiParameter>; cast to OpenApiParameter for mutation.
         foreach (var parameter in openApiOperation.Parameters)
         {
-            var description = apiDescription.ParameterDescriptions.FirstOrDefault(p => p.Name == parameter.Name);
+            if (parameter is not OpenApiParameter concreteParam) continue;
+
+            var description = apiDescription.ParameterDescriptions.FirstOrDefault(p => p.Name == concreteParam.Name);
             if (description == null)
                 continue;
 
-            parameter.Description ??= description.ModelMetadata?.Description;
+            concreteParam.Description ??= description.ModelMetadata?.Description;
 
-            if (
-                parameter.Schema.Default == null
+            if (concreteParam.Schema is OpenApiSchema concreteSchema
+                && concreteSchema.Default == null
                 && description.DefaultValue != null
                 && description.DefaultValue is not DBNull
-                && description.ModelMetadata is { } modelMetadata
-            )
+                && description.ModelMetadata is { } modelMetadata)
             {
                 // REF: https://github.com/Microsoft/aspnet-api-versioning/issues/429#issuecomment-605402330
                 var json = JsonSerializer.Serialize(description.DefaultValue, modelMetadata.ModelType);
-                parameter.Schema.Default = JsonNode.Parse(json);
+                concreteSchema.Default = JsonNode.Parse(json);
             }
 
-            parameter.Required |= description.IsRequired;
+            concreteParam.Required |= description.IsRequired;
         }
 
         return Task.CompletedTask;

--- a/Tycoon.Shared/OpenApi/Swashbuckle/CorrelationIdHeaderOperationFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/CorrelationIdHeaderOperationFilter.cs
@@ -10,7 +10,7 @@ public class CorrelationIdHeaderOperationFilter : IOperationFilter
 
     public void Apply(OpenApiOperation operation, OperationFilterContext context)
     {
-        operation.Parameters ??= new List<OpenApiParameter>();
+        operation.Parameters ??= new List<IOpenApiParameter>();
 
         // Add the Correlation ID header to the operation parameters
         operation.Parameters.Add(
@@ -22,7 +22,7 @@ public class CorrelationIdHeaderOperationFilter : IOperationFilter
                 Required = false, // Set to true if the header is mandatory
                 Schema = new OpenApiSchema
                 {
-                    Type = "string",
+                    Type = JsonSchemaType.String,
                     Example = JsonValue.Create("123e4567-e89b-12d3-a456-426614174000"), // Example GUID
                 },
             }

--- a/Tycoon.Shared/OpenApi/Swashbuckle/EnumSchemaFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/EnumSchemaFilter.cs
@@ -18,6 +18,6 @@ public class EnumSchemaFilter : ISchemaFilter
         concreteSchema.Enum.Clear();
         Enum.GetNames(context.Type).ToList()
             .ForEach(name => concreteSchema.Enum.Add(JsonValue.Create(name)!));
-        concreteSchema.Type = "string";
+        concreteSchema.Type = JsonSchemaType.String;
     }
 }

--- a/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
@@ -86,23 +86,12 @@ public static class DependencyInjectionExtensions
         );
 
         // Add Security Requirements
+        // OpenAPI 2.0: OpenApiReference was removed; OpenApiSecurityRequirement is now Dictionary<string, IList<string>>.
         options.AddSecurityRequirement(
             new OpenApiSecurityRequirement
             {
-                {
-                    new OpenApiSecurityScheme
-                    {
-                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "Bearer" },
-                    },
-                    new List<string>() // No specific scopes for bearer
-                },
-                {
-                    new OpenApiSecurityScheme
-                    {
-                        Reference = new OpenApiReference { Type = ReferenceType.SecurityScheme, Id = "ApiKey" },
-                    },
-                    new List<string>() // No specific scopes for API Key
-                },
+                { "Bearer", Array.Empty<string>() },
+                { "ApiKey", Array.Empty<string>() },
             }
         );
     }

--- a/Tycoon.Shared/OpenApi/Swashbuckle/SwaggerDefaultValuesOperationFilter.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/SwaggerDefaultValuesOperationFilter.cs
@@ -1,4 +1,4 @@
-﻿using System.Text.Json;
+using System.Text.Json;
 using System.Text.Json.Nodes;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi;
@@ -19,10 +19,12 @@ public class SwaggerDefaultValuesOperationFilter : IOperationFilter
     public void Apply(OpenApiOperation openApiOperation, OperationFilterContext context)
     {
         var apiDescription = context.ApiDescription;
-        var actionDescriptor = apiDescription.ActionDescriptor;
-        var endpointMetadata = actionDescriptor.EndpointMetadata;
 
-        openApiOperation.Deprecated |= apiDescription.IsDeprecated();
+        // IsDeprecated() extension was removed in Swashbuckle 10 — check endpoint metadata directly.
+        var isDeprecated = apiDescription.ActionDescriptor.EndpointMetadata
+            .OfType<ObsoleteAttribute>()
+            .Any();
+        openApiOperation.Deprecated |= isDeprecated;
 
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/1752#issue-663991077
         foreach (var responseType in context.ApiDescription.SupportedResponseTypes)
@@ -47,27 +49,29 @@ public class SwaggerDefaultValuesOperationFilter : IOperationFilter
 
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/412
         // REF: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/pull/413
+        // OpenAPI 2.0: Parameters is IList<IOpenApiParameter>; cast to OpenApiParameter for mutation.
         foreach (var parameter in openApiOperation.Parameters)
         {
-            var description = apiDescription.ParameterDescriptions.FirstOrDefault(p => p.Name == parameter.Name);
+            if (parameter is not OpenApiParameter concreteParam) continue;
+
+            var description = apiDescription.ParameterDescriptions.FirstOrDefault(p => p.Name == concreteParam.Name);
             if (description == null)
                 continue;
 
-            parameter.Description ??= description.ModelMetadata?.Description;
+            concreteParam.Description ??= description.ModelMetadata?.Description;
 
-            if (
-                parameter.Schema.Default == null
+            if (concreteParam.Schema is OpenApiSchema concreteSchema
+                && concreteSchema.Default == null
                 && description.DefaultValue != null
                 && description.DefaultValue is not DBNull
-                && description.ModelMetadata is { } modelMetadata
-            )
+                && description.ModelMetadata is { } modelMetadata)
             {
                 // REF: https://github.com/Microsoft/aspnet-api-versioning/issues/429#issuecomment-605402330
                 var json = JsonSerializer.Serialize(description.DefaultValue, modelMetadata.ModelType);
-                parameter.Schema.Default = JsonNode.Parse(json);
+                concreteSchema.Default = JsonNode.Parse(json);
             }
 
-            parameter.Required |= description.IsRequired;
+            concreteParam.Required |= description.IsRequired;
         }
     }
 }


### PR DESCRIPTION
OpenAPI 2.0 follow-on fixes (second wave):

1. JsonSchemaType enum — OpenApiSchema.Type is now JsonSchemaType? (flags enum), not string. Replace Type = "string" with Type = JsonSchemaType.String in: EnumSchemaFilter, EnumSchemaTransformer, CorrelationIdHeaderOperationFilter, CorrelationIdHeaderOperationTransformer.

2. IOpenApiParameter / IOpenApiSchema read-only interfaces — OpenApiOperation.Parameters is now IList<IOpenApiParameter>; the interface members Required, Schema.Default are get-only. Cast to OpenApiParameter / OpenApiSchema inside the parameter loop in SwaggerDefaultValuesOperationFilter and OpenApiDefaultValuesOperationTransformer.

3. IList<IOpenApiParameter> ??= type mismatch — new List<OpenApiParameter>() is not assignable to IList<IOpenApiParameter>; changed to new List<IOpenApiParameter>() in both CorrelationId filters.

4. OpenApiReference removed — OpenApiSecurityRequirement is now Dictionary<string, IList<string>>; replaced the old Reference = new OpenApiReference { ... } key pattern with plain string keys { "Bearer", Array.Empty<string>() } in DependencyInjectionExtensions.

5. IsDeprecated() extension removed from Swashbuckle 10 — inlined as EndpointMetadata.OfType<ObsoleteAttribute>().Any() in both default-values filters.

OTel fix:
6. EntityFrameworkInstrumentationOptions.SetDbStatementForText removed in OpenTelemetry.Instrumentation.EntityFrameworkCore 1.x (security: SQL text capture is opt-in via a different mechanism). Collapsed the lambda to a no-argument AddEntityFrameworkCoreInstrumentation() call.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2