### PR TITLE
Fix OpenApiSecurityRequirement key type in Swashbuckle 10 / OpenAPI 2.0

### DIFF
--- a/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
@@ -86,12 +86,12 @@ public static class DependencyInjectionExtensions
         );
 
         // Add Security Requirements
-        // OpenAPI 2.0: OpenApiReference was removed; OpenApiSecurityRequirement is now Dictionary<string, IList<string>>.
+        // OpenAPI 2.0: OpenApiSecurityRequirement is Dictionary<OpenApiSecuritySchemeReference, List<string>>.
         options.AddSecurityRequirement(
             new OpenApiSecurityRequirement
             {
-                { "Bearer", Array.Empty<string>() },
-                { "ApiKey", Array.Empty<string>() },
+                { new OpenApiSecuritySchemeReference("Bearer"), new List<string>() },
+                { new OpenApiSecuritySchemeReference("ApiKey"), new List<string>() },
             }
         );
     }


### PR DESCRIPTION
OpenApiSecurityRequirement is Dictionary<OpenApiSecuritySchemeReference, List<string>>, not Dictionary<string, List<string>> as previously assumed. Replace plain string keys with new OpenApiSecuritySchemeReference("Bearer/ApiKey").

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2