### PR TITLE
Fix AddSecurityRequirement signature in Swashbuckle 10

### DIFF
--- a/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
+++ b/Tycoon.Shared/OpenApi/Swashbuckle/Extensions/DependencyInjectionExtensions.cs
@@ -86,13 +86,11 @@ public static class DependencyInjectionExtensions
         );
 
         // Add Security Requirements
-        // OpenAPI 2.0: OpenApiSecurityRequirement is Dictionary<OpenApiSecuritySchemeReference, List<string>>.
-        options.AddSecurityRequirement(
-            new OpenApiSecurityRequirement
-            {
-                { new OpenApiSecuritySchemeReference("Bearer"), new List<string>() },
-                { new OpenApiSecuritySchemeReference("ApiKey"), new List<string>() },
-            }
-        );
+        // Swashbuckle 10: AddSecurityRequirement takes Func<OpenApiDocument, OpenApiSecurityRequirement>.
+        options.AddSecurityRequirement(_ => new OpenApiSecurityRequirement
+        {
+            { new OpenApiSecuritySchemeReference("Bearer"), new List<string>() },
+            { new OpenApiSecuritySchemeReference("ApiKey"), new List<string>() },
+        });
     }
 }


### PR DESCRIPTION
Swashbuckle 10 changed AddSecurityRequirement to accept Func<OpenApiDocument, OpenApiSecurityRequirement> instead of a direct OpenApiSecurityRequirement value. Wrap the initializer in a lambda.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2