### PR TITLE
Fix Stripe.net 51 breaking changes in gateway and endpoints

### DIFF
--- a/Tycoon.Backend.Api/Features/Store/StoreEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Store/StoreEndpoints.cs
@@ -939,8 +939,8 @@ namespace Tycoon.Backend.Api.Features.Store
                 return ApiResponses.Error(StatusCodes.Status503ServiceUnavailable, "STRIPE_NOT_READY", ex.Message);
             }
 
-            if (string.Equals(webhookEvent.EventType, global::Stripe.Events.CustomerSubscriptionUpdated, StringComparison.Ordinal)
-                || string.Equals(webhookEvent.EventType, global::Stripe.Events.CustomerSubscriptionDeleted, StringComparison.Ordinal))
+            if (string.Equals(webhookEvent.EventType, global::Stripe.EventTypes.CustomerSubscriptionUpdated, StringComparison.Ordinal)
+                || string.Equals(webhookEvent.EventType, global::Stripe.EventTypes.CustomerSubscriptionDeleted, StringComparison.Ordinal))
             {
                 var subEvent = webhookEvent.SubscriptionChanged;
                 if (subEvent is null)
@@ -980,7 +980,7 @@ namespace Tycoon.Backend.Api.Features.Store
                 return Results.Ok(new { received = true, applied = true, eventType = webhookEvent.EventType });
             }
 
-            if (!string.Equals(webhookEvent.EventType, global::Stripe.Events.CheckoutSessionCompleted, StringComparison.Ordinal))
+            if (!string.Equals(webhookEvent.EventType, global::Stripe.EventTypes.CheckoutSessionCompleted, StringComparison.Ordinal))
                 return Results.Ok(new { received = true, ignored = true, eventType = webhookEvent.EventType });
 
             var completed = webhookEvent.CheckoutCompleted;

--- a/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
+++ b/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
@@ -160,7 +160,7 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
             stripeEvent = EventUtility.ParseEvent(payload);
         }
 
-        if (stripeEvent.Type == Events.CheckoutSessionCompleted
+        if (stripeEvent.Type == EventTypes.CheckoutSessionCompleted
             && stripeEvent.Data.Object is global::Stripe.Checkout.Session session)
         {
             return new StripeWebhookEvent(
@@ -180,8 +180,8 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
                 null);
         }
 
-        if ((stripeEvent.Type == Events.CustomerSubscriptionUpdated
-            || stripeEvent.Type == Events.CustomerSubscriptionDeleted)
+        if ((stripeEvent.Type == EventTypes.CustomerSubscriptionUpdated
+            || stripeEvent.Type == EventTypes.CustomerSubscriptionDeleted)
             && stripeEvent.Data.Object is Subscription subscription)
         {
             return new StripeWebhookEvent(
@@ -193,7 +193,7 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
                     subscription.CustomerId,
                     subscription.Status,
                     subscription.CancelAtPeriodEnd,
-                    subscription.CurrentPeriodEnd,
+                    subscription.CurrentPeriodEndAt,
                     subscription.Metadata ?? new Dictionary<string, string>()));
         }
 


### PR DESCRIPTION
- Events static class renamed to EventTypes in Stripe.net 46+. Replace Events.CheckoutSessionCompleted / CustomerSubscriptionUpdated / CustomerSubscriptionDeleted with EventTypes.* in StripePaymentGateway.cs and StoreEndpoints.cs (global::Stripe.Events.* → global::Stripe.EventTypes.*).

- Subscription.CurrentPeriodEnd renamed to CurrentPeriodEndAt in Stripe.net 47+.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2