### PR TITLE
Fix Subscription type ambiguity in StripePaymentGateway

### DIFF
--- a/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
+++ b/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
@@ -182,7 +182,7 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
 
         if ((stripeEvent.Type == EventTypes.CustomerSubscriptionUpdated
             || stripeEvent.Type == EventTypes.CustomerSubscriptionDeleted)
-            && stripeEvent.Data.Object is Subscription subscription)
+            && stripeEvent.Data.Object is global::Stripe.Subscription subscription)
         {
             return new StripeWebhookEvent(
                 stripeEvent.Id,
@@ -193,7 +193,7 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
                     subscription.CustomerId,
                     subscription.Status,
                     subscription.CancelAtPeriodEnd,
-                    subscription.CurrentPeriodEndAt,
+                    subscription.CurrentPeriodEnd,
                     subscription.Metadata ?? new Dictionary<string, string>()));
         }
 


### PR DESCRIPTION
The file lives in namespace Tycoon.Backend.Api.Payments.Stripe, whose trailing 'Stripe' segment causes C# to fail resolving the unqualified 'Subscription' pattern-match type via 'using Stripe;'. Qualify the pattern as global::Stripe.Subscription so the compiler finds the correct type. Also revert CurrentPeriodEndAt → CurrentPeriodEnd, which is the correct property name on Stripe.Subscription in v51.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2