### PR TITLE
Fix Subscription.CurrentPeriodEnd removed in Stripe.net v48

### DIFF
--- a/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
+++ b/Tycoon.Backend.Api/Payments/Stripe/StripePaymentGateway.cs
@@ -193,7 +193,10 @@ public sealed class StripePaymentGateway : IStripePaymentGateway
                     subscription.CustomerId,
                     subscription.Status,
                     subscription.CancelAtPeriodEnd,
-                    subscription.CurrentPeriodEnd,
+                    // Stripe.net v48: CurrentPeriodEnd moved from Subscription to SubscriptionItem.
+                    subscription.Items?.Data?.FirstOrDefault()?.CurrentPeriodEnd is { } periodEnd
+                        ? new DateTimeOffset(periodEnd, TimeSpan.Zero)
+                        : (DateTimeOffset?)null,
                     subscription.Metadata ?? new Dictionary<string, string>()));
         }
 


### PR DESCRIPTION
Stripe.net v48.0.0 removed CurrentPeriodEnd from Subscription and kept it only on SubscriptionItem (added there in v45.1.0). Access via subscription.Items.Data[0].CurrentPeriodEnd; convert DateTime to DateTimeOffset? for the StripeWebhookSubscriptionData parameter.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2