### PR TITLE
Remove deprecated .WithOpenApi() calls and fix obsolete UsePostgreSql…

### DIFF
--- a/Tycoon.Backend.Api/Features/AdminAnalytics/AdminAnalyticsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAnalytics/AdminAnalyticsEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.AdminAnalytics
         {
             var g = admin.MapGroup("/analytics")
                 .WithTags("Admin/Analytics")
-                .WithOpenApi();
+                ;
 
             // POST /admin/analytics/rebuild-elastic-rollups?from=2025-01-01&to=2025-01-31
             g.MapPost("/rebuild-elastic-rollups", async (

--- a/Tycoon.Backend.Api/Features/AdminAnalytics/AdminAuditEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAnalytics/AdminAuditEndpoints.cs
@@ -13,7 +13,7 @@ public static class AdminAuditEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/audit").WithTags("Admin/Audit").WithOpenApi();
+        var g = admin.MapGroup("/audit").WithTags("Admin/Audit");
 
         g.MapGet("/security", async (
             [FromQuery] DateTimeOffset? from,

--- a/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminAntiCheatAnalyticsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminAntiCheatAnalyticsEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.AdminAntiCheat
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/anti-cheat/analytics").WithTags("Admin/AntiCheat").WithOpenApi();
+            var g = admin.MapGroup("/anti-cheat/analytics").WithTags("Admin/AntiCheat");
 
             g.MapGet("/summary", async (
                 [FromQuery] int windowHours,

--- a/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminAntiCheatEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminAntiCheatEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.AdminAntiCheat
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/anti-cheat").WithTags("Admin/AntiCheat").WithOpenApi();
+            var g = admin.MapGroup("/anti-cheat").WithTags("Admin/AntiCheat");
 
             g.MapGet("/flags", async (
                 [FromQuery] int page,

--- a/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminPartyAntiCheatEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAntiCheat/AdminPartyAntiCheatEndpoints.cs
@@ -14,7 +14,7 @@ namespace Tycoon.Backend.Api.Features.AdminAntiCheat
         public static void Map(IEndpointRouteBuilder admin)
         {
             var g = admin.MapGroup("/anti-cheat/party")
-                .WithTags("Admin AntiCheat - Party").WithOpenApi();
+                .WithTags("Admin AntiCheat - Party");
 
             // GET /admin/anti-cheat/party/flags?sinceUtc=...&ruleKeyPrefix=party-&page=1&pageSize=50
             g.MapGet("/flags", async (

--- a/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminAuth/AdminAuthEndpoints.cs
@@ -41,7 +41,7 @@ public static class AdminAuthEndpoints
 
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/auth").WithTags("Admin/Auth").WithOpenApi();
+        var g = admin.MapGroup("/auth").WithTags("Admin/Auth");
 
         g.MapPost("/login", Login).RequireRateLimiting("admin-auth-login");
         g.MapPost("/refresh", Refresh).RequireRateLimiting("admin-auth-refresh");

--- a/Tycoon.Backend.Api/Features/AdminConfig/AdminConfigEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminConfig/AdminConfigEndpoints.cs
@@ -14,7 +14,7 @@ public static class AdminConfigEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/config").WithTags("Admin/Config").WithOpenApi();
+        var g = admin.MapGroup("/config").WithTags("Admin/Config");
 
         g.MapGet("", async (IAppDb db, CancellationToken ct) =>
         {

--- a/Tycoon.Backend.Api/Features/AdminEconomy/AdminEconomyEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminEconomy/AdminEconomyEndpoints.cs
@@ -14,7 +14,7 @@ namespace Tycoon.Backend.Api.Features.AdminEconomy
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/economy").WithTags("Admin/Economy").WithOpenApi();
+            var g = admin.MapGroup("/economy").WithTags("Admin/Economy");
 
             g.MapPost("/transactions", async ([FromBody] CreateEconomyTxnRequest req, EconomyService econ, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminEmailAcl/AdminEmailAclEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminEmailAcl/AdminEmailAclEndpoints.cs
@@ -15,7 +15,7 @@ public static class AdminEmailAclEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/email-acl").WithTags("Admin/EmailAcl").WithOpenApi();
+        var g = admin.MapGroup("/email-acl").WithTags("Admin/EmailAcl");
 
         // List all ACL entries (paginated, filterable by list type)
         g.MapGet("/", async (

--- a/Tycoon.Backend.Api/Features/AdminEventQueue/AdminEventQueueEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminEventQueue/AdminEventQueueEndpoints.cs
@@ -13,7 +13,7 @@ public static class AdminEventQueueEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/event-queue").WithTags("Admin/EventQueue").WithOpenApi();
+        var g = admin.MapGroup("/event-queue").WithTags("Admin/EventQueue");
 
         g.MapPost("/upload", Upload);
         g.MapPost("/reprocess", Reprocess);

--- a/Tycoon.Backend.Api/Features/AdminExperiments/AdminExperimentEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminExperiments/AdminExperimentEndpoints.cs
@@ -14,7 +14,7 @@ public static class AdminExperimentEndpoints
 
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/experiments").WithTags("Admin/Experiments").WithOpenApi();
+        var g = admin.MapGroup("/experiments").WithTags("Admin/Experiments");
 
         g.MapGet("/", ListExperiments);
         g.MapGet("/{id:guid}", GetExperiment);

--- a/Tycoon.Backend.Api/Features/AdminLearningModules/AdminLearningModulesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminLearningModules/AdminLearningModulesEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.AdminLearningModules
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/modules").WithTags("Admin/LearningModules").WithOpenApi();
+            var g = admin.MapGroup("/modules").WithTags("Admin/LearningModules");
 
             // List all modules (including unpublished)
             g.MapGet("", async (

--- a/Tycoon.Backend.Api/Features/AdminMatches/AdminMatchesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminMatches/AdminMatchesEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.AdminMatches
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/matches").WithTags("Admin/Matches").WithOpenApi();
+            var g = admin.MapGroup("/matches").WithTags("Admin/Matches");
 
             g.MapGet("", async (
                 [FromQuery] int page,

--- a/Tycoon.Backend.Api/Features/AdminMedia/AdminMediaEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminMedia/AdminMediaEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.AdminMedia
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/media").WithTags("Admin/Media").WithOpenApi();
+            var g = admin.MapGroup("/media").WithTags("Admin/Media");
 
             g.MapPost("/intent", async ([FromBody] CreateUploadIntentRequest req, MediaService media, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminModeration/AdminEscalationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminModeration/AdminEscalationEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.AdminModeration
 
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/moderation/escalation").WithTags("Admin/Moderation").WithOpenApi();
+            var g = admin.MapGroup("/moderation/escalation").WithTags("Admin/Moderation");
 
             g.MapPost("/run", async (
                 HttpContext ctx,

--- a/Tycoon.Backend.Api/Features/AdminModeration/AdminModerationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminModeration/AdminModerationEndpoints.cs
@@ -16,7 +16,7 @@ namespace Tycoon.Backend.Api.Features.AdminModeration
 
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/moderation").WithTags("Admin/Moderation").WithOpenApi();
+            var g = admin.MapGroup("/moderation").WithTags("Admin/Moderation");
 
             g.MapGet("/profile/{playerId:guid}", async (
                 [FromRoute] Guid playerId,

--- a/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminNotifications/AdminNotificationsEndpoints.cs
@@ -18,7 +18,7 @@ public static class AdminNotificationsEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/notifications").WithTags("Admin/Notifications").WithOpenApi();
+        var g = admin.MapGroup("/notifications").WithTags("Admin/Notifications");
 
         g.MapGet("/channels", async (IAppDb db, CancellationToken ct) =>
         {

--- a/Tycoon.Backend.Api/Features/AdminPersonalization/AdminPersonalizationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminPersonalization/AdminPersonalizationEndpoints.cs
@@ -14,7 +14,7 @@ public static class AdminPersonalizationEndpoints
 
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/personalization").WithTags("Admin/Personalization").WithOpenApi();
+        var g = admin.MapGroup("/personalization").WithTags("Admin/Personalization");
 
         g.MapGet("/summary", GetSummary);
         g.MapGet("/archetypes", GetArchetypes);

--- a/Tycoon.Backend.Api/Features/AdminPlayerTransactions/AdminPlayerTransactionEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminPlayerTransactions/AdminPlayerTransactionEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.AdminPlayerTransactions
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/player-transactions").WithTags("Admin/PlayerTransactions").WithOpenApi();
+            var g = admin.MapGroup("/player-transactions").WithTags("Admin/PlayerTransactions");
 
             // Create / execute a composite player transaction
             g.MapPost("", async ([FromBody] CreatePlayerTransactionRequest req, PlayerTransactionService svc, CancellationToken ct) =>

--- a/Tycoon.Backend.Api/Features/AdminPowerups/AdminPowerupsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminPowerups/AdminPowerupsEndpoints.cs
@@ -11,7 +11,7 @@ namespace Tycoon.Backend.Api.Features.AdminPowerups
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/powerups").WithTags("Admin/Powerups").WithOpenApi();
+            var g = admin.MapGroup("/powerups").WithTags("Admin/Powerups");
 
             g.MapPost("/grant", async ([FromBody] GrantPowerupRequest req, PowerupService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminQuestions/AdminQuestionsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminQuestions/AdminQuestionsEndpoints.cs
@@ -17,10 +17,10 @@ namespace Tycoon.Backend.Api.Features.AdminQuestions
         public static void Map(RouteGroupBuilder admin)
         {
             // Contract-compliant route surface: /admin/questions
-            var g = admin.MapGroup("/questions").WithTags("Admin/Questions").WithOpenApi();
+            var g = admin.MapGroup("/questions").WithTags("Admin/Questions");
 
             // Backward-compatible legacy route surface: /admin/admin/questions
-            var legacy = admin.MapGroup("/admin/questions").WithTags("Admin/Questions (Legacy)").WithOpenApi();
+            var legacy = admin.MapGroup("/admin/questions").WithTags("Admin/Questions (Legacy)");
 
             MapRoutes(g);
             MapRoutes(legacy);

--- a/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonLifecycleEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonLifecycleEndpoints.cs
@@ -10,7 +10,7 @@ public static class AdminSeasonLifecycleEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/seasons").WithTags("Admin/Seasons").WithOpenApi();
+        var g = admin.MapGroup("/seasons").WithTags("Admin/Seasons");
 
         g.MapPost("/{seasonId:guid}/close", async (
             Guid seasonId,

--- a/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonPointsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonPointsEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.AdminSeasons
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/season-points").WithTags("Admin/SeasonPoints").WithOpenApi();
+            var g = admin.MapGroup("/season-points").WithTags("Admin/SeasonPoints");
 
             g.MapPost("/transactions", async ([FromBody] ApplySeasonPointsRequest req, SeasonPointsService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonRewardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonRewardsEndpoints.cs
@@ -12,7 +12,7 @@ public static class AdminSeasonRewardsEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/seasons/rewards").WithTags("Admin/Seasons/Rewards").WithOpenApi();
+        var g = admin.MapGroup("/seasons/rewards").WithTags("Admin/Seasons/Rewards");
 
         // Audit claims
         g.MapGet("/claims", async (

--- a/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminSeasons/AdminSeasonsEndpoints.cs
@@ -14,7 +14,7 @@ namespace Tycoon.Backend.Api.Features.AdminSeasons
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/seasons").WithTags("Admin/Seasons").WithOpenApi();
+            var g = admin.MapGroup("/seasons").WithTags("Admin/Seasons");
 
             g.MapGet("", async ([FromQuery] int page, [FromQuery] int pageSize, SeasonService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminSkills/AdminSkillsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminSkills/AdminSkillsEndpoints.cs
@@ -11,7 +11,7 @@ namespace Tycoon.Backend.Api.Features.AdminSkills
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/skills").WithTags("Admin/Skills").WithOpenApi();
+            var g = admin.MapGroup("/skills").WithTags("Admin/Skills");
 
             g.MapPost("/seed", async ([FromBody] SkillTreeCatalogDto req, SkillTreeService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/AdminStore/AdminStoreEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminStore/AdminStoreEndpoints.cs
@@ -17,7 +17,7 @@ public static class AdminStoreEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/store").WithTags("Admin/Store").WithOpenApi();
+        var g = admin.MapGroup("/store").WithTags("Admin/Store");
 
         // Catalog + system status (existing)
         g.MapGet("/system/status", GetSystemStatus);

--- a/Tycoon.Backend.Api/Features/AdminUsers/AdminUsersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminUsers/AdminUsersEndpoints.cs
@@ -13,7 +13,7 @@ public static class AdminUsersEndpoints
 {
     public static void Map(RouteGroupBuilder admin)
     {
-        var g = admin.MapGroup("/users").WithTags("Admin/Users").WithOpenApi();
+        var g = admin.MapGroup("/users").WithTags("Admin/Users");
 
         g.MapGet("", ListUsers);
         g.MapGet("/{userId}", GetUser);

--- a/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Analytics/AnalyticsEndpoints.cs
@@ -13,8 +13,8 @@ namespace Tycoon.Backend.Api.Features.Analytics
     {
         public static void Map(WebApplication app)
         {
-            var analytics = app.MapGroup("/analytics").WithTags("Analytics").WithOpenApi();
-            var analyticsV1 = app.MapGroup("/api/v1/analytics").WithTags("Analytics").WithOpenApi();
+            var analytics = app.MapGroup("/analytics").WithTags("Analytics");
+            var analyticsV1 = app.MapGroup("/api/v1/analytics").WithTags("Analytics");
 
             MapIngestionRoutes(analytics);
             MapIngestionRoutes(analyticsV1);

--- a/Tycoon.Backend.Api/Features/Auth/AuthEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Auth/AuthEndpoints.cs
@@ -10,7 +10,7 @@ namespace Tycoon.Backend.Api.Features.Auth
     {
         public static void Map(WebApplication app)
         {
-            var authGroup = app.MapGroup("/auth").WithTags("Authentication").WithOpenApi();
+            var authGroup = app.MapGroup("/auth").WithTags("Authentication");
 
             authGroup.MapPost("/register", HandleRegistration);
             authGroup.MapPost("/signup", HandleSignup);

--- a/Tycoon.Backend.Api/Features/Avatars/AvatarEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Avatars/AvatarEndpoints.cs
@@ -15,14 +15,14 @@ namespace Tycoon.Backend.Api.Features.Avatars
         {
             var purchaseGroup = app.MapGroup("/store/avatars")
                 .WithTags("Avatars")
-                .WithOpenApi()
+                
                 .RequireAuthorization();
 
             purchaseGroup.MapPost("/{avatarId}/purchase", PurchaseAvatar);
 
             var assetsGroup = app.MapGroup("/v1/assets/avatars")
                 .WithTags("AvatarAssets")
-                .WithOpenApi()
+                
                 .RequireAuthorization();
 
             assetsGroup.MapGet("/{avatarId}", GetAvatarAsset);

--- a/Tycoon.Backend.Api/Features/Coach/CoachEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Coach/CoachEndpoints.cs
@@ -11,7 +11,7 @@ public static class CoachEndpoints
         var group = app.MapGroup("/coach")
             .RequireAuthorization()
             .WithTags("Coach")
-            .WithOpenApi();
+            ;
 
         group.MapGet("/{playerId:guid}/daily-brief", async (
             Guid playerId,

--- a/Tycoon.Backend.Api/Features/Crypto/CryptoEconomyEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Crypto/CryptoEconomyEndpoints.cs
@@ -14,7 +14,7 @@ public static class CryptoEconomyEndpoints
 {
     public static void Map(WebApplication app)
     {
-        var g = app.MapGroup("/crypto").WithTags("Crypto Economy").WithOpenApi();
+        var g = app.MapGroup("/crypto").WithTags("Crypto Economy");
 
         g.MapPost("/link-wallet", LinkWallet).RequireAuthorization();
         g.MapGet("/balance/{playerId:guid}", GetBalance).RequireAuthorization();

--- a/Tycoon.Backend.Api/Features/Experiments/ExperimentEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Experiments/ExperimentEndpoints.cs
@@ -10,7 +10,7 @@ public static class ExperimentEndpoints
         var g = app.MapGroup("/experiments")
             .WithTags("Experiments")
             .RequireAuthorization()
-            .WithOpenApi();
+            ;
 
         // Bootstrap all active experiment assignments for a player at session start
         g.MapGet("/player/{playerId:guid}", GetAllAssignments);

--- a/Tycoon.Backend.Api/Features/Friends/FriendsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Friends/FriendsEndpoints.cs
@@ -26,7 +26,7 @@ namespace Tycoon.Backend.Api.Features.Friends
         public static void Map(IEndpointRouteBuilder app)
         {
             var g = app.MapGroup("/friends")
-                .WithTags("Friends").WithOpenApi();
+                .WithTags("Friends");
 
             // POST /friends/request
             g.MapPost("/request", async (

--- a/Tycoon.Backend.Api/Features/GameEvents/AdminGameEventsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/GameEvents/AdminGameEventsEndpoints.cs
@@ -16,7 +16,7 @@ namespace Tycoon.Backend.Api.Features.GameEvents
     {
         public static void Map(RouteGroupBuilder admin)
         {
-            var g = admin.MapGroup("/game-events").WithTags("Admin/GameEvents").WithOpenApi();
+            var g = admin.MapGroup("/game-events").WithTags("Admin/GameEvents");
 
             g.MapGet("/", async (
                 [FromQuery] int page,

--- a/Tycoon.Backend.Api/Features/GameEvents/GameEventStatsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/GameEvents/GameEventStatsEndpoints.cs
@@ -11,7 +11,7 @@ namespace Tycoon.Backend.Api.Features.GameEvents
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/game-events").WithTags("GameEventStats").WithOpenApi();
+            var g = app.MapGroup("/game-events").WithTags("GameEventStats");
 
             // Ranked leaderboard for a specific closed game event
             g.MapGet("/{gameEventId:guid}/leaderboard", async (
@@ -60,7 +60,7 @@ namespace Tycoon.Backend.Api.Features.GameEvents
 
         public static void MapTerritory(WebApplication app)
         {
-            var g = app.MapGroup("/territory").WithTags("TerritoryStats").WithOpenApi();
+            var g = app.MapGroup("/territory").WithTags("TerritoryStats");
 
             // Territory dominance leaderboard for a tier
             g.MapGet("/{seasonId:guid}/{tierNumber:int}/dominance", async (

--- a/Tycoon.Backend.Api/Features/GameEvents/GameEventsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/GameEvents/GameEventsEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.GameEvents
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/game-events").WithTags("GameEvents").WithOpenApi();
+            var g = app.MapGroup("/game-events").WithTags("GameEvents");
 
             g.MapPost("/enter", async (
                 [FromBody] EnterGameEventRequest req,

--- a/Tycoon.Backend.Api/Features/Guardians/GuardiansEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Guardians/GuardiansEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.Guardians
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/guardians").WithTags("Guardians").WithOpenApi();
+            var g = app.MapGroup("/guardians").WithTags("Guardians");
 
             g.MapGet("/{tierNumber:int}", async (
                 [FromRoute] int tierNumber,

--- a/Tycoon.Backend.Api/Features/Leaderboards/LeaderboardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Leaderboards/LeaderboardsEndpoints.cs
@@ -14,11 +14,11 @@ namespace Tycoon.Backend.Api.Features.Leaderboards
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/leaderboards").WithTags("Leaderboards").WithOpenApi();
+            var g = app.MapGroup("/leaderboards").WithTags("Leaderboards");
 
             // Frontend compatibility route(s): some clients call singular /leaderboard.
-            MapLegacyLeaderboard(app.MapGroup("/leaderboard").WithTags("Leaderboards").WithOpenApi());
-            MapLegacyLeaderboard(app.MapGroup("/api/v1/leaderboard").WithTags("Leaderboards").WithOpenApi());
+            MapLegacyLeaderboard(app.MapGroup("/leaderboard").WithTags("Leaderboards"));
+            MapLegacyLeaderboard(app.MapGroup("/api/v1/leaderboard").WithTags("Leaderboards"));
 
             // Existing: keep for now (until auth-sub binding is enforced)
             g.MapGet("/me/{playerId:guid}", async (Guid playerId, IMediator mediator, CancellationToken ct) =>

--- a/Tycoon.Backend.Api/Features/Leaderboards/RankedLeaderboardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Leaderboards/RankedLeaderboardsEndpoints.cs
@@ -10,7 +10,7 @@ public static class RankedLeaderboardsEndpoints
 {
     public static void Map(WebApplication app)
     {
-        var g = app.MapGroup("/leaderboards/ranked").WithTags("Leaderboards/Ranked").WithOpenApi();
+        var g = app.MapGroup("/leaderboards/ranked").WithTags("Leaderboards/Ranked");
 
         g.MapGet("", async (
             [FromQuery] Guid? seasonId,

--- a/Tycoon.Backend.Api/Features/LearningModules/LearningModulesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/LearningModules/LearningModulesEndpoints.cs
@@ -14,7 +14,7 @@ namespace Tycoon.Backend.Api.Features.LearningModules
         {
             // Public learning contract.
             // /modules is the supported backend surface for guided mastery and lesson progression.
-            var g = app.MapGroup("/modules").WithTags("LearningModules").WithOpenApi();
+            var g = app.MapGroup("/modules").WithTags("LearningModules");
 
             // Browse published modules (public)
             // Optional: ?playerId={guid} populates isCompleted per module

--- a/Tycoon.Backend.Api/Features/Matches/MatchesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Matches/MatchesEndpoints.cs
@@ -17,7 +17,7 @@ namespace Tycoon.Backend.Api.Features.Matches
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/matches").WithTags("Matches").WithOpenApi();
+            var g = app.MapGroup("/matches").WithTags("Matches");
 
             g.MapPost("/start", async (
                 [FromBody] StartMatchRequest req,

--- a/Tycoon.Backend.Api/Features/Matchmaking/MatchmakingEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Matchmaking/MatchmakingEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.Matchmaking
         public sealed record CancelRequest(Guid PlayerId);
         public static void Map(IEndpointRouteBuilder app)
         {
-            var g = app.MapGroup("/matchmaking").WithTags("Matchmaking").WithOpenApi();
+            var g = app.MapGroup("/matchmaking").WithTags("Matchmaking");
 
             g.MapPost("/enqueue", async (
                 [FromBody] EnqueueRequest req,

--- a/Tycoon.Backend.Api/Features/Missions/MissionsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Missions/MissionsEndpoints.cs
@@ -16,7 +16,7 @@ namespace Tycoon.Backend.Api.Features.Missions
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/missions").WithTags("Missions").WithOpenApi();
+            var g = app.MapGroup("/missions").WithTags("Missions");
 
             g.MapGet("/", async ([FromQuery] string? type, IMediator mediator, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Ml/MlScoringEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Ml/MlScoringEndpoints.cs
@@ -11,7 +11,7 @@ public static class MlScoringEndpoints
 {
     public static void Map(WebApplication app)
     {
-        var g = app.MapGroup("/ml").WithTags("ML").WithOpenApi().RequireAuthorization();
+        var g = app.MapGroup("/ml").WithTags("ML").RequireAuthorization();
         g.MapPost("/churn-risk", EstimateChurnRisk);
         g.MapPost("/match-quality", EstimateMatchQuality);
     }

--- a/Tycoon.Backend.Api/Features/Mobile/Economy/MobileEconomyEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Economy/MobileEconomyEndpoints.cs
@@ -11,7 +11,7 @@ public static class MobileEconomyEndpoints
 {
     public static void Map(RouteGroupBuilder mobile)
     {
-        var g = mobile.MapGroup("/economy").WithTags("Mobile/Economy").WithOpenApi();
+        var g = mobile.MapGroup("/economy").WithTags("Mobile/Economy");
 
         g.MapGet("/state", async (IGameBalancePolicyService policy, CancellationToken ct) =>
         {

--- a/Tycoon.Backend.Api/Features/Mobile/Leaderboards/MobileLeaderboardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Leaderboards/MobileLeaderboardsEndpoints.cs
@@ -13,7 +13,7 @@ namespace Tycoon.Backend.Api.Features.Mobile.Leaderboards
         {
             var g = mobile.MapGroup("/leaderboards")
                 .WithTags("Mobile/Leaderboards")
-                .WithOpenApi();
+                ;
 
             g.MapGet("/me/{playerId:guid}", async (Guid playerId, IMediator mediator, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Mobile/Matches/MobileMatchesEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Matches/MobileMatchesEndpoints.cs
@@ -25,7 +25,7 @@ namespace Tycoon.Backend.Api.Features.Mobile.Matches
         {
             var g = mobile.MapGroup("/matches")
                 .WithTags("Mobile/Matches")
-                .WithOpenApi();
+                ;
 
             g.MapPost("/start", async (
                 [FromBody] StartMatchRequest req,

--- a/Tycoon.Backend.Api/Features/Mobile/Players/MobilePlayersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Players/MobilePlayersEndpoints.cs
@@ -16,7 +16,7 @@ namespace Tycoon.Backend.Api.Features.Mobile.Players
         {
             var g = mobile.MapGroup("/players")
                 .WithTags("Mobile/Players")
-                .WithOpenApi();
+                ;
 
             g.MapPost("/", async ([FromBody] CreatePlayerRequest req, AppDb db, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Mobile/Seasons/MobileSeasonsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Mobile/Seasons/MobileSeasonsEndpoints.cs
@@ -15,7 +15,7 @@ namespace Tycoon.Backend.Api.Features.Mobile.Seasons
         {
             var g = mobile.MapGroup("/seasons")
                 .WithTags("Mobile/Seasons")
-                .WithOpenApi();
+                ;
 
             g.MapGet("/active", async (SeasonService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Party/PartyEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Party/PartyEndpoints.cs
@@ -20,7 +20,7 @@ namespace Tycoon.Backend.Api.Features.Party
         public static void Map(IEndpointRouteBuilder app)
         {
             var g = app.MapGroup("/party")
-                .WithTags("Party").WithOpenApi();
+                .WithTags("Party");
 
             // POST /party
             g.MapPost("", async (

--- a/Tycoon.Backend.Api/Features/Personalization/PersonalizationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Personalization/PersonalizationEndpoints.cs
@@ -11,7 +11,7 @@ public static class PersonalizationEndpoints
         var group = app.MapGroup("/personalization")
             .RequireAuthorization()
             .WithTags("Personalization")
-            .WithOpenApi();
+            ;
 
         group.MapGet("/profile/{playerId:guid}", async (
             Guid playerId,

--- a/Tycoon.Backend.Api/Features/Players/PlayersEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Players/PlayersEndpoints.cs
@@ -16,7 +16,7 @@ namespace Tycoon.Backend.Api.Features.Players
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/players").WithTags("Players").WithOpenApi();
+            var g = app.MapGroup("/players").WithTags("Players");
 
             g.MapPost("/", async ([FromBody] CreatePlayerRequest req, AppDb db, CancellationToken ct) =>
             {
@@ -34,7 +34,7 @@ namespace Tycoon.Backend.Api.Features.Players
                 return dto is null ? Results.NotFound() : Results.Ok(dto);
             });
 
-            g.MapGet("/{id:guid}/stats", GetCareerStats).WithOpenApi();
+            g.MapGet("/{id:guid}/stats", GetCareerStats);
         }
 
         private static async Task<IResult> GetCareerStats(

--- a/Tycoon.Backend.Api/Features/Powerups/PowerupsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Powerups/PowerupsEndpoints.cs
@@ -10,7 +10,7 @@ namespace Tycoon.Backend.Api.Features.Powerups
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/powerups").WithTags("Powerups").WithOpenApi();
+            var g = app.MapGroup("/powerups").WithTags("Powerups");
 
             g.MapGet("/state/{playerId:guid}", async ([FromRoute] Guid playerId, PowerupService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Qr/QrEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Qr/QrEndpoints.cs
@@ -11,7 +11,7 @@ namespace Tycoon.Backend.Api.Features.Qr
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/qr").WithTags("QR").WithOpenApi();
+            var g = app.MapGroup("/qr").WithTags("QR");
 
             g.MapPost("/track-scan", async ([FromBody] TrackScanRequest req, IMediator mediator, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Questions/QuestionsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Questions/QuestionsEndpoints.cs
@@ -15,7 +15,7 @@ namespace Tycoon.Backend.Api.Features.Questions
             // Public gameplay question contract.
             // /questions is the supported backend surface for play-oriented retrieval and grading.
             // Legacy /quiz routes are intentionally not mapped here.
-            var g = app.MapGroup("/questions").WithTags("Questions").WithOpenApi();
+            var g = app.MapGroup("/questions").WithTags("Questions");
 
             g.MapGet("/set", GetQuestionSet);
             g.MapGet("/categories", GetCategories);

--- a/Tycoon.Backend.Api/Features/Referrals/ReferralsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Referrals/ReferralsEndpoints.cs
@@ -11,7 +11,7 @@ namespace Tycoon.Backend.Api.Features.Referrals
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/referrals").WithTags("Referrals").WithOpenApi();
+            var g = app.MapGroup("/referrals").WithTags("Referrals");
 
             g.MapPost("/", async ([FromBody] CreateReferralCodeRequest req, IMediator mediator, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Seasons/SeasonRewardsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Seasons/SeasonRewardsEndpoints.cs
@@ -10,7 +10,7 @@ public static class SeasonRewardsEndpoints
 {
     public static void Map(WebApplication app)
     {
-        var g = app.MapGroup("/seasons/rewards").WithTags("Seasons/Rewards").WithOpenApi();
+        var g = app.MapGroup("/seasons/rewards").WithTags("Seasons/Rewards");
 
         // Eligibility (UI hook)
         g.MapGet("/eligibility/{playerId:guid}", async (

--- a/Tycoon.Backend.Api/Features/Seasons/SeasonsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Seasons/SeasonsEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.Seasons
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/seasons").WithTags("Seasons").WithOpenApi();
+            var g = app.MapGroup("/seasons").WithTags("Seasons");
 
             g.MapGet("/active", async (SeasonService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Skills/SkillsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Skills/SkillsEndpoints.cs
@@ -10,7 +10,7 @@ namespace Tycoon.Backend.Api.Features.Skills
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/skills").WithTags("Skills").WithOpenApi();
+            var g = app.MapGroup("/skills").WithTags("Skills");
 
             g.MapGet("/tree", async (SkillTreeService svc, CancellationToken ct) =>
             {

--- a/Tycoon.Backend.Api/Features/Store/StoreEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Store/StoreEndpoints.cs
@@ -30,7 +30,7 @@ namespace Tycoon.Backend.Api.Features.Store
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/store").WithTags("Store").WithOpenApi();
+            var g = app.MapGroup("/store").WithTags("Store");
 
             g.MapGet("/catalog", GetCatalog);
             g.MapGet("/catalog/{sku}", GetItem);

--- a/Tycoon.Backend.Api/Features/Study/StudySessionsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Study/StudySessionsEndpoints.cs
@@ -15,7 +15,7 @@ namespace Tycoon.Backend.Api.Features.Study
         {
             var g = app.MapGroup("/study-sessions")
                 .WithTags("StudySessions")
-                .WithOpenApi()
+                
                 .RequireAuthorization();
 
             g.MapPost("", async (

--- a/Tycoon.Backend.Api/Features/Study/StudySetsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Study/StudySetsEndpoints.cs
@@ -15,7 +15,7 @@ namespace Tycoon.Backend.Api.Features.Study
         {
             // Public study contract.
             // /study-sets is the dedicated backend surface for rehearsal-style study flows.
-            var g = app.MapGroup("/study-sets").WithTags("StudySets").WithOpenApi();
+            var g = app.MapGroup("/study-sets").WithTags("StudySets");
 
             g.MapGet("", async (
                 [FromQuery] Guid? playerId,

--- a/Tycoon.Backend.Api/Features/Territory/TerritoryEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Territory/TerritoryEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.Territory
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/territory").WithTags("Territory").WithOpenApi();
+            var g = app.MapGroup("/territory").WithTags("Territory");
 
             g.MapGet("/{seasonId:guid}/{tierNumber:int}", async (
                 [FromRoute] Guid seasonId,

--- a/Tycoon.Backend.Api/Features/Users/UserFriendsEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Users/UserFriendsEndpoints.cs
@@ -19,7 +19,7 @@ namespace Tycoon.Backend.Api.Features.Users
         {
             var g = app.MapGroup("/users/me/friends")
                 .WithTags("Friends")
-                .WithOpenApi()
+                
                 .RequireAuthorization();
 
             // GET /users/me/friends

--- a/Tycoon.Backend.Api/Features/Votes/VoteEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/Votes/VoteEndpoints.cs
@@ -12,7 +12,7 @@ namespace Tycoon.Backend.Api.Features.Votes
     {
         public static void Map(WebApplication app)
         {
-            var g = app.MapGroup("/votes").WithTags("Votes").WithOpenApi();
+            var g = app.MapGroup("/votes").WithTags("Votes");
 
             // POST /votes
             g.MapPost("/", async (

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -332,13 +332,15 @@ if (hangfireEnabled)
             cfg.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
                .UseSimpleAssemblyNameTypeSerializer()
                .UseRecommendedSerializerSettings()
-               .UsePostgreSqlStorage(hangfireDb, new PostgreSqlStorageOptions
-               {
-                   QueuePollInterval = TimeSpan.FromSeconds(5),
-                   InvisibilityTimeout = TimeSpan.FromMinutes(5),
-                   PrepareSchemaIfNecessary = true,
-                   SchemaName = "hangfire"
-               }));
+               .UsePostgreSqlStorage(
+                   opts => opts.UseNpgsqlConnection(hangfireDb),
+                   new PostgreSqlStorageOptions
+                   {
+                       QueuePollInterval = TimeSpan.FromSeconds(5),
+                       InvisibilityTimeout = TimeSpan.FromMinutes(5),
+                       PrepareSchemaIfNecessary = true,
+                       SchemaName = "hangfire"
+                   }));
 
         builder.Services.AddHangfireServer(options =>
         {
@@ -845,7 +847,7 @@ GuardiansEndpoints.Map(app);
 TerritoryEndpoints.Map(app);
 
 // Mobile endpoints (separate route surface for mobile-specific contracts/workflows)
-var mobile = app.MapGroup("/mobile").WithTags("Mobile").WithOpenApi();
+var mobile = app.MapGroup("/mobile").WithTags("Mobile");
 MobileMatchesEndpoints.Map(mobile);
 MobilePlayersEndpoints.Map(mobile);
 MobileLeaderboardsEndpoints.Map(mobile);


### PR DESCRIPTION
…Storage overload

- Strip all 74 .WithOpenApi() call sites from ~65 endpoint files and Program.cs (ASPDEPR002: WithOpenApi is deprecated in ASP.NET Core 10; OpenAPI metadata is now inferred automatically by the native middleware without explicit opt-in)
- Replace obsolete UsePostgreSqlStorage(string, options) with the new UsePostgreSqlStorage(Action<PostgreSqlBootstrapperOptions>, options) overload introduced in Hangfire.PostgreSql 1.20+; connection string now passed via opts.UseNpgsqlConnection(hangfireDb) inside the configuration lambda

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2