### PR TITLE
Implement personalization hardening: audit trail, feature flags, conf…

### DIFF
--- a/Tycoon.Backend.Api/Features/AdminPersonalization/AdminPersonalizationEndpoints.cs
+++ b/Tycoon.Backend.Api/Features/AdminPersonalization/AdminPersonalizationEndpoints.cs
@@ -23,6 +23,7 @@ public static class AdminPersonalizationEndpoints
         g.MapGet("/archetypes", GetArchetypes);
         g.MapGet("/recommendations/performance", GetRecommendationPerformance);
         g.MapGet("/player/{playerId:guid}", GetPlayerProfile);
+        g.MapGet("/debug/{playerId:guid}", GetDebug);
         g.MapPost("/player/{playerId:guid}/recalculate", RecalculatePlayer);
         g.MapPost("/player/{playerId:guid}/reset", ResetPlayer);
         g.MapGet("/rules", GetRules);
@@ -88,6 +89,29 @@ public static class AdminPersonalizationEndpoints
     {
         var profile = await profiles.GetOrCreateAsync(playerId, ct);
         return Results.Ok(profile);
+    }
+
+    private static async Task<IResult> GetDebug(Guid playerId, IAppDb db, CancellationToken ct)
+    {
+        var profile = await db.PlayerMindProfiles
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.PlayerId == playerId, ct);
+
+        var recentEvents = await db.PlayerBehaviorEvents
+            .AsNoTracking()
+            .Where(x => x.PlayerId == playerId)
+            .OrderByDescending(x => x.OccurredAt)
+            .Take(25)
+            .ToListAsync(ct);
+
+        var recentAudit = await db.PersonalizationAuditLogs
+            .AsNoTracking()
+            .Where(x => x.PlayerId == playerId)
+            .OrderByDescending(x => x.CreatedAt)
+            .Take(25)
+            .ToListAsync(ct);
+
+        return Results.Ok(new { playerId, profile, recentEvents, recentAudit });
     }
 
     private static async Task<IResult> RecalculatePlayer(

--- a/Tycoon.Backend.Api/Program.cs
+++ b/Tycoon.Backend.Api/Program.cs
@@ -87,6 +87,7 @@ using Tycoon.Backend.Api.Realtime;
 using Tycoon.Backend.Api.Security;
 using Tycoon.Backend.Application;
 using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Application.Personalization;
 using Tycoon.Backend.Application.Analytics.Abstractions;
 using Tycoon.Backend.Application.Analytics.Writers;
 using Tycoon.Backend.Application.Auth;
@@ -511,6 +512,9 @@ builder.Services.AddSchemaGate(builder.Configuration, builder.Environment);
 // take it as a service dependency (avoids startup parameter-inference failures).
 builder.Services.AddMemoryCache();
 builder.Services.AddHttpClient();
+builder.Services.Configure<PersonalizationOptions>(
+    builder.Configuration.GetSection("Personalization"));
+
 builder.Services.AddHttpClient<IPersonalizationSidecarClient, PersonalizationSidecarClient>(client =>
 {
     var baseUrl = builder.Configuration["SidecarPersonalization:BaseUrl"] ?? "http://localhost:8001";

--- a/Tycoon.Backend.Api/appsettings.Development.json
+++ b/Tycoon.Backend.Api/appsettings.Development.json
@@ -196,5 +196,21 @@
         "ValidIssuer": "dotnet-user-jwts"
       }
     }
+  },
+  "Personalization": {
+    "Enabled": true,
+    "UseSidecar": true,
+    "AdaptiveQuestions": false,
+    "AdaptiveMissions": true,
+    "AdaptiveStore": true,
+    "AdaptiveNotifications": true,
+    "CoachEnabled": true,
+    "FrustrationPaidOfferSuppressionThreshold": 0.75,
+    "NotificationFatigueThreshold": 0.70
+  },
+  "SidecarPersonalization": {
+    "BaseUrl": "http://localhost:8001",
+    "TimeoutSeconds": 3,
+    "Enabled": true
   }
 }

--- a/Tycoon.Backend.Application/Abstractions/IAppDb.cs
+++ b/Tycoon.Backend.Application/Abstractions/IAppDb.cs
@@ -98,6 +98,7 @@ namespace Tycoon.Backend.Application.Abstractions
         DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents { get; }
         DbSet<PersonalizationRecommendation> PersonalizationRecommendations { get; }
         DbSet<PersonalizationRule> PersonalizationRules { get; }
+        DbSet<PersonalizationAuditLog> PersonalizationAuditLogs { get; }
 
         // A/B Experiments
         DbSet<Experiment> Experiments { get; }

--- a/Tycoon.Backend.Application/DependencyInjection.cs
+++ b/Tycoon.Backend.Application/DependencyInjection.cs
@@ -122,6 +122,7 @@ namespace Tycoon.Backend.Application
             services.AddScoped<Personalization.IPlayerMindProfileService, Personalization.PlayerMindProfileService>();
             services.AddScoped<Personalization.IPersonalizationService, Personalization.PersonalizationService>();
             services.AddScoped<Personalization.IPersonalizationGuardrailService, Personalization.PersonalizationGuardrailService>();
+            services.AddScoped<Personalization.IPersonalizationAuditService, Personalization.PersonalizationAuditService>();
 
             // A/B Experiments
             services.AddScoped<Experiments.IExperimentService, Experiments.ExperimentService>();

--- a/Tycoon.Backend.Application/Personalization/IPersonalizationAuditService.cs
+++ b/Tycoon.Backend.Application/Personalization/IPersonalizationAuditService.cs
@@ -1,0 +1,16 @@
+namespace Tycoon.Backend.Application.Personalization;
+
+public interface IPersonalizationAuditService
+{
+    Task LogDecisionAsync(
+        Guid playerId,
+        Guid? recommendationId,
+        string decisionType,
+        string source,
+        string reason,
+        object inputSignals,
+        object candidate,
+        object guardrails,
+        object finalDecision,
+        CancellationToken ct = default);
+}

--- a/Tycoon.Backend.Application/Personalization/PersonalizationAuditService.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationAuditService.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+using Tycoon.Backend.Application.Abstractions;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Application.Personalization;
+
+public sealed class PersonalizationAuditService : IPersonalizationAuditService
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    private readonly IAppDb _db;
+
+    public PersonalizationAuditService(IAppDb db)
+    {
+        _db = db;
+    }
+
+    public async Task LogDecisionAsync(
+        Guid playerId,
+        Guid? recommendationId,
+        string decisionType,
+        string source,
+        string reason,
+        object inputSignals,
+        object candidate,
+        object guardrails,
+        object finalDecision,
+        CancellationToken ct = default)
+    {
+        _db.PersonalizationAuditLogs.Add(new PersonalizationAuditLog
+        {
+            Id = Guid.NewGuid(),
+            PlayerId = playerId,
+            RecommendationId = recommendationId,
+            DecisionType = decisionType,
+            Source = source,
+            Reason = reason,
+            InputSignalsJson = JsonSerializer.Serialize(inputSignals, _json),
+            CandidateJson = JsonSerializer.Serialize(candidate, _json),
+            GuardrailsAppliedJson = JsonSerializer.Serialize(guardrails, _json),
+            FinalDecisionJson = JsonSerializer.Serialize(finalDecision, _json),
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/Tycoon.Backend.Application/Personalization/PersonalizationGuardrailService.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationGuardrailService.cs
@@ -1,20 +1,42 @@
+using Microsoft.Extensions.Options;
 using Tycoon.Shared.Contracts.Dtos;
 
 namespace Tycoon.Backend.Application.Personalization;
 
 public sealed class PersonalizationGuardrailService : IPersonalizationGuardrailService
 {
+    private readonly PersonalizationOptions _options;
+
+    public PersonalizationGuardrailService(IOptions<PersonalizationOptions> options)
+    {
+        _options = options.Value;
+    }
+
     public PersonalizationGuardrailResult Apply(PlayerMindProfileDto profile, PersonalizationCandidateDto candidate)
     {
         var rules = new Dictionary<string, object>();
 
-        if (candidate.Type == "store_offer" && profile.FrustrationRiskScore >= 0.75m)
+        if (!_options.Enabled)
+        {
+            rules["personalization_disabled"] = true;
+            return new(false, "Personalization is disabled.", rules);
+        }
+
+        if (!profile.PersonalizationEnabled)
+        {
+            rules["player_personalization_disabled"] = true;
+            return new(false, "Personalization is disabled for this player.", rules);
+        }
+
+        if (candidate.Type == "store_offer" &&
+            profile.FrustrationRiskScore >= _options.FrustrationPaidOfferSuppressionThreshold)
         {
             rules["suppress_paid_offers_when_frustrated"] = true;
             return new(false, "Paid offers suppressed due to high frustration risk.", rules);
         }
 
-        if (candidate.Type == "notification" && profile.NotificationFatigueScore >= 0.70m)
+        if (candidate.Type == "notification" &&
+            profile.NotificationFatigueScore >= _options.NotificationFatigueThreshold)
         {
             rules["notification_fatigue_limit"] = true;
             return new(false, "Notification suppressed due to fatigue risk.", rules);
@@ -24,12 +46,6 @@ public sealed class PersonalizationGuardrailService : IPersonalizationGuardrailS
         {
             rules["ranked_fairness_lock"] = true;
             return new(false, "Ranked difficulty cannot be modified by personalization.", rules);
-        }
-
-        if (!profile.PersonalizationEnabled)
-        {
-            rules["personalization_disabled"] = true;
-            return new(false, "Personalization is disabled for this player.", rules);
         }
 
         rules["allowed"] = true;

--- a/Tycoon.Backend.Application/Personalization/PersonalizationOptions.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationOptions.cs
@@ -1,0 +1,15 @@
+namespace Tycoon.Backend.Application.Personalization;
+
+public sealed class PersonalizationOptions
+{
+    public bool Enabled { get; set; } = true;
+    public bool UseSidecar { get; set; } = true;
+    public bool AdaptiveQuestions { get; set; } = false;
+    public bool AdaptiveMissions { get; set; } = true;
+    public bool AdaptiveStore { get; set; } = true;
+    public bool AdaptiveNotifications { get; set; } = true;
+    public bool CoachEnabled { get; set; } = true;
+
+    public decimal FrustrationPaidOfferSuppressionThreshold { get; set; } = 0.75m;
+    public decimal NotificationFatigueThreshold { get; set; } = 0.70m;
+}

--- a/Tycoon.Backend.Application/Personalization/PersonalizationService.cs
+++ b/Tycoon.Backend.Application/Personalization/PersonalizationService.cs
@@ -14,17 +14,20 @@ public sealed class PersonalizationService : IPersonalizationService
     private readonly IPlayerMindProfileService _profiles;
     private readonly IPersonalizationGuardrailService _guardrails;
     private readonly IPersonalizationSidecarClient _sidecar;
+    private readonly IPersonalizationAuditService _audit;
 
     public PersonalizationService(
         IAppDb db,
         IPlayerMindProfileService profiles,
         IPersonalizationGuardrailService guardrails,
-        IPersonalizationSidecarClient sidecar)
+        IPersonalizationSidecarClient sidecar,
+        IPersonalizationAuditService audit)
     {
         _db = db;
         _profiles = profiles;
         _guardrails = guardrails;
         _sidecar = sidecar;
+        _audit = audit;
     }
 
     public async Task<PlayerHomePersonalizationDto> GetHomeAsync(Guid playerId, CancellationToken ct = default)
@@ -112,9 +115,11 @@ public sealed class PersonalizationService : IPersonalizationService
             var guardCandidate = new PersonalizationCandidateDto(candidate.Type, candidate.Score, candidate.Payload);
             var guardrailResult = _guardrails.Apply(profile, guardCandidate);
 
+            var recId = Guid.NewGuid();
+
             var rec = new PersonalizationRecommendation
             {
-                Id = Guid.NewGuid(),
+                Id = recId,
                 PlayerId = playerId,
                 RecommendationType = candidate.Type,
                 Source = "sidecar",
@@ -126,6 +131,18 @@ public sealed class PersonalizationService : IPersonalizationService
             };
 
             _db.PersonalizationRecommendations.Add(rec);
+
+            await _audit.LogDecisionAsync(
+                playerId,
+                recId,
+                guardrailResult.Allowed ? "allowed" : "blocked",
+                "sidecar",
+                guardrailResult.BlockReason ?? candidate.Reason,
+                profile,
+                candidate,
+                guardrailResult.AppliedRules,
+                new { guardrailResult.Allowed },
+                ct);
 
             if (guardrailResult.Allowed)
             {

--- a/Tycoon.Backend.Domain/Personalization/PersonalizationAuditLog.cs
+++ b/Tycoon.Backend.Domain/Personalization/PersonalizationAuditLog.cs
@@ -1,0 +1,20 @@
+namespace Tycoon.Backend.Domain.Personalization;
+
+public sealed class PersonalizationAuditLog
+{
+    public Guid Id { get; set; }
+    public Guid PlayerId { get; set; }
+
+    public Guid? RecommendationId { get; set; }
+
+    public string DecisionType { get; set; } = "";
+    public string Source { get; set; } = "backend";
+    public string Reason { get; set; } = "";
+
+    public string InputSignalsJson { get; set; } = "{}";
+    public string CandidateJson { get; set; } = "{}";
+    public string GuardrailsAppliedJson { get; set; } = "{}";
+    public string FinalDecisionJson { get; set; } = "{}";
+
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+}

--- a/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/AppDb.cs
@@ -115,6 +115,7 @@ namespace Tycoon.Backend.Infrastructure.Persistence
         public DbSet<PlayerBehaviorEvent> PlayerBehaviorEvents => Set<PlayerBehaviorEvent>();
         public DbSet<PersonalizationRecommendation> PersonalizationRecommendations => Set<PersonalizationRecommendation>();
         public DbSet<PersonalizationRule> PersonalizationRules => Set<PersonalizationRule>();
+        public DbSet<PersonalizationAuditLog> PersonalizationAuditLogs => Set<PersonalizationAuditLog>();
 
         // A/B Experiments
         public DbSet<Experiment> Experiments => Set<Experiment>();

--- a/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationAuditLogConfiguration.cs
+++ b/Tycoon.Backend.Infrastructure/Persistence/Configurations/PersonalizationAuditLogConfiguration.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Tycoon.Backend.Domain.Personalization;
+
+namespace Tycoon.Backend.Infrastructure.Persistence.Configurations;
+
+public sealed class PersonalizationAuditLogConfiguration : IEntityTypeConfiguration<PersonalizationAuditLog>
+{
+    public void Configure(EntityTypeBuilder<PersonalizationAuditLog> b)
+    {
+        b.ToTable("personalization_audit_logs");
+
+        b.HasKey(x => x.Id);
+        b.Property(x => x.Id).HasColumnName("id");
+        b.Property(x => x.PlayerId).HasColumnName("player_id");
+        b.Property(x => x.RecommendationId).HasColumnName("recommendation_id");
+
+        b.Property(x => x.DecisionType).HasColumnName("decision_type").HasMaxLength(128);
+        b.Property(x => x.Source).HasColumnName("source").HasMaxLength(64).HasDefaultValue("backend");
+        b.Property(x => x.Reason).HasColumnName("reason").HasMaxLength(512).HasDefaultValue("");
+
+        b.Property(x => x.InputSignalsJson).HasColumnName("input_signals_json").HasColumnType("jsonb").HasDefaultValue("{}");
+        b.Property(x => x.CandidateJson).HasColumnName("candidate_json").HasColumnType("jsonb").HasDefaultValue("{}");
+        b.Property(x => x.GuardrailsAppliedJson).HasColumnName("guardrails_applied_json").HasColumnType("jsonb").HasDefaultValue("{}");
+        b.Property(x => x.FinalDecisionJson).HasColumnName("final_decision_json").HasColumnType("jsonb").HasDefaultValue("{}");
+
+        b.Property(x => x.CreatedAt).HasColumnName("created_at");
+
+        b.HasIndex(x => new { x.PlayerId, x.CreatedAt }).HasDatabaseName("ix_personalization_audit_logs_player_created");
+        b.HasIndex(x => x.DecisionType).HasDatabaseName("ix_personalization_audit_logs_decision_type");
+        b.HasIndex(x => x.RecommendationId).HasDatabaseName("ix_personalization_audit_logs_recommendation_id");
+    }
+}

--- a/Tycoon.Backend.Migrations/Migrations/20260430120000_AddPersonalizationAuditLog.cs
+++ b/Tycoon.Backend.Migrations/Migrations/20260430120000_AddPersonalizationAuditLog.cs
@@ -1,0 +1,57 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tycoon.Backend.Migrations.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPersonalizationAuditLog : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "personalization_audit_logs",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    player_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    recommendation_id = table.Column<Guid>(type: "uuid", nullable: true),
+                    decision_type = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    source = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false, defaultValue: "backend"),
+                    reason = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: false, defaultValue: ""),
+                    input_signals_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    candidate_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    guardrails_applied_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    final_decision_json = table.Column<string>(type: "jsonb", nullable: false, defaultValue: "{}"),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_personalization_audit_logs", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_audit_logs_player_created",
+                table: "personalization_audit_logs",
+                columns: new[] { "player_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_audit_logs_decision_type",
+                table: "personalization_audit_logs",
+                column: "decision_type");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_personalization_audit_logs_recommendation_id",
+                table: "personalization_audit_logs",
+                column: "recommendation_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(name: "personalization_audit_logs");
+        }
+    }
+}


### PR DESCRIPTION
…igurable guardrails

New files:
- PersonalizationAuditLog domain model + EF configuration
- PersonalizationOptions feature-flag class (Enabled, UseSidecar, AdaptiveX flags, FrustrationPaidOfferSuppressionThreshold, NotificationFatigueThreshold)
- IPersonalizationAuditService + PersonalizationAuditService (writes structured decision records per recommendation with input signals, candidate, guardrail outcome, and final decision to personalization_audit_logs)
- Migration 20260430120000_AddPersonalizationAuditLog creates the audit table with player+created composite index, decision_type index, recommendation_id index

Updated files:
- PersonalizationGuardrailService: now takes IOptions<PersonalizationOptions>
  so frustration/fatigue thresholds are runtime-configurable rather than hardcoded
- PersonalizationService: injects IPersonalizationAuditService and calls LogDecisionAsync for every recommendation decision (allowed or blocked)
- AppDb + IAppDb: PersonalizationAuditLogs DbSet added
- AdminPersonalizationEndpoints: GET /admin/personalization/debug/{playerId} returns profile + last-25 behavior events + last-25 audit log entries
- DependencyInjection: registers IPersonalizationAuditService
- Program.cs: Configure<PersonalizationOptions>("Personalization") + using import
- appsettings.Development.json: Personalization and SidecarPersonalization sections

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2