### PR TITLE
Update Dockerfiles to .NET 10 SDK and runtime images

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -1,7 +1,7 @@
 # ================================
 # Build Stage - Optimized with layer caching
 # ================================
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy Central Package Management files first (rarely change)
@@ -38,7 +38,7 @@ RUN dotnet publish "Tycoon.Backend.Api.csproj" \
 # ================================
 # Runtime Stage - Minimal image
 # ================================
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 # Install curl for health checks

--- a/docker/Dockerfile.dashboard
+++ b/docker/Dockerfile.dashboard
@@ -1,7 +1,7 @@
 # ================================
 # Build Stage - Optimized with layer caching
 # ================================
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy Central Package Management files first (rarely change)
@@ -33,7 +33,7 @@ RUN dotnet publish "Tycoon.OperatorDashboard.csproj" \
 # ================================
 # Runtime Stage - Minimal image
 # ================================
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 # Install curl for health checks

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -1,7 +1,7 @@
 # ================================
 # Build Stage - Optimized with layer caching
 # ================================
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 ARG BUILD_CONFIGURATION=Release
 WORKDIR /src
 
@@ -44,7 +44,7 @@ RUN apt-get update && apt-get install -y \
 # ================================
 # Runtime Stage
 # ================================
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS final
 WORKDIR /app
 
 # Required by Npgsql/Kerberos-capable auth paths to avoid runtime shared-library warnings

--- a/docker/Dockerfile.migration-service
+++ b/docker/Dockerfile.migration-service
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
 WORKDIR /app
 
 # Install Kerberos libraries for PostgreSQL authentication
@@ -7,7 +7,7 @@ RUN apt-get update && apt-get install -y \
     krb5-user \
     && rm -rf /var/lib/apt/lists/*
 
-FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
 WORKDIR /src
 
 # Copy project files


### PR DESCRIPTION
Replace mcr.microsoft.com/dotnet/sdk:9.0 and aspnet:9.0 with 10.0 across all four .NET Dockerfiles so Docker builds match the global.json SDK pin of 10.0.100 set during the .NET 10 upgrade.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2