### PR TITLE
Fix pending migrations SQL and Docker user creation for .NET 10

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -47,8 +47,8 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Create non-root user for security
-RUN addgroup --system --gid 1000 appuser && \
-    adduser --system --uid 1000 --ingroup appuser --shell /bin/false appuser
+RUN groupadd --system --gid 1000 appuser && \
+    useradd --system --uid 1000 --gid appuser --shell /bin/false --no-create-home appuser
 
 # Copy published files
 COPY --from=build /app/publish .

--- a/docker/Dockerfile.migrate
+++ b/docker/Dockerfile.migrate
@@ -54,8 +54,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends libgssapi-krb5-
 COPY --from=build /app/publish .
 
 # Run as non-root user
-RUN addgroup --system --gid 1000 appuser && \
-    adduser --system --uid 1000 --ingroup appuser --shell /bin/false appuser && \
+RUN groupadd --system --gid 1000 appuser && \
+    useradd --system --uid 1000 --gid appuser --shell /bin/false --no-create-home appuser && \
     chown -R appuser:appuser /app
 
 USER appuser

--- a/docs/pending_migrations_2026-04-29.sql
+++ b/docs/pending_migrations_2026-04-29.sql
@@ -1,10 +1,12 @@
 -- =============================================================================
 -- Pending EF Migrations — Apply before May 15 cutover
--- Generated: 2026-04-29
+-- Generated: 2026-04-29 | Updated: 2026-05-01
 -- Target DB: PostgreSQL (Npgsql EF Core naming conventions: snake_case)
 --
 -- Run order matters — execute top-to-bottom in a single transaction.
--- After applying, run: dotnet ef database update (or re-run to confirm idempotency)
+-- After applying, verify with:
+--   SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "MigrationId";
+-- Expected last row: 20260501090000_AddReasonToPersonalizationRecommendation
 -- =============================================================================
 
 BEGIN;
@@ -23,32 +25,11 @@ ALTER TABLE store_items
     ADD COLUMN IF NOT EXISTS version       character varying(20);
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260422132225_AddStoreItemAvatarFields', '9.0.0')
+VALUES ('20260422132225_AddStoreItemAvatarFields', '9.0.11')
 ON CONFLICT DO NOTHING;
 
 -- =============================================================================
--- 2. 20260425120000_AddSeasonRewardRules
---    Defines per-tier season rewards (XP + coins) for end-of-season payouts
--- =============================================================================
-
-CREATE TABLE IF NOT EXISTS season_reward_rules (
-    id            uuid     NOT NULL,
-    tier          integer  NOT NULL,
-    max_tier_rank integer  NOT NULL,
-    reward_xp     integer  NOT NULL,
-    reward_coins  integer  NOT NULL,
-    CONSTRAINT pk_season_reward_rules PRIMARY KEY (id)
-);
-
-CREATE UNIQUE INDEX IF NOT EXISTS ix_season_reward_rules_tier_max_tier_rank
-    ON season_reward_rules (tier, max_tier_rank);
-
-INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260425120000_AddSeasonRewardRules', '9.0.0')
-ON CONFLICT DO NOTHING;
-
--- =============================================================================
--- 3. 20260425130000_AddStoreStockSystem
+-- 2. 20260425130000_AddStoreStockSystem
 --    Per-SKU purchase limits (policies) and per-player purchase tracking
 -- =============================================================================
 
@@ -84,11 +65,11 @@ CREATE UNIQUE INDEX IF NOT EXISTS ix_player_store_stock_states_player_id_sku
     ON player_store_stock_states (player_id, sku);
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260425130000_AddStoreStockSystem', '9.0.0')
+VALUES ('20260425130000_AddStoreStockSystem', '9.0.11')
 ON CONFLICT DO NOTHING;
 
 -- =============================================================================
--- 4. 20260425140000_AddFlashSale
+-- 3. 20260425140000_AddFlashSale
 --    Time-windowed discount promotions tied to a SKU
 -- =============================================================================
 
@@ -111,7 +92,28 @@ CREATE INDEX IF NOT EXISTS ix_flash_sales_sku_window
     ON flash_sales (sku, starts_at_utc, ends_at_utc);
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260425140000_AddFlashSale', '9.0.0')
+VALUES ('20260425140000_AddFlashSale', '9.0.11')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- 4. 20260425150120_AddSeasonRewardRules
+--    Defines per-tier season rewards (XP + coins) for end-of-season payouts
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS season_reward_rules (
+    id            uuid     NOT NULL,
+    tier          integer  NOT NULL,
+    max_tier_rank integer  NOT NULL,
+    reward_xp     integer  NOT NULL,
+    reward_coins  integer  NOT NULL,
+    CONSTRAINT pk_season_reward_rules PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_season_reward_rules_tier_max_tier_rank
+    ON season_reward_rules (tier, max_tier_rank);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260425150120_AddSeasonRewardRules', '9.0.11')
 ON CONFLICT DO NOTHING;
 
 -- =============================================================================
@@ -134,7 +136,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS ix_reward_claim_rules_reward_id
     ON reward_claim_rules (reward_id);
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260426100000_AddRewardClaimRule', '9.0.0')
+VALUES ('20260426100000_AddRewardClaimRule', '9.0.11')
 ON CONFLICT DO NOTHING;
 
 -- =============================================================================
@@ -147,13 +149,227 @@ ALTER TABLE player_store_stock_states
     ADD COLUMN IF NOT EXISTS effective_max_quantity integer;
 
 INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
-VALUES ('20260426110000_AddEffectiveMaxQuantity', '9.0.0')
+VALUES ('20260426110000_AddEffectiveMaxQuantity', '9.0.11')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- 7. 20260429100000_AddPersonalizationTables
+--    Creates player_mind_profiles, player_behavior_events,
+--    personalization_recommendations, and personalization_rules
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS player_mind_profiles (
+    id                          uuid                        NOT NULL,
+    player_id                   uuid                        NOT NULL,
+    confidence_level            numeric(5,2)                NOT NULL DEFAULT 0.50,
+    risk_tolerance              numeric(5,2)                NOT NULL DEFAULT 0.50,
+    preferred_pace              character varying(64)       NOT NULL DEFAULT 'balanced',
+    learning_style              character varying(64)       NOT NULL DEFAULT 'mixed',
+    competitive_preference      character varying(64)       NOT NULL DEFAULT 'balanced',
+    social_preference           character varying(64)       NOT NULL DEFAULT 'solo',
+    churn_risk_score            numeric(5,2)                NOT NULL DEFAULT 0.00,
+    frustration_risk_score      numeric(5,2)                NOT NULL DEFAULT 0.00,
+    reward_sensitivity_score    numeric(5,2)                NOT NULL DEFAULT 0.50,
+    store_affinity_score        numeric(5,2)                NOT NULL DEFAULT 0.50,
+    notification_fatigue_score  numeric(5,2)                NOT NULL DEFAULT 0.00,
+    archetype                   character varying(96)       NOT NULL DEFAULT 'new_player',
+    category_strengths_json     jsonb                       NOT NULL DEFAULT '{}',
+    category_weaknesses_json    jsonb                       NOT NULL DEFAULT '{}',
+    preference_json             jsonb                       NOT NULL DEFAULT '{}',
+    guardrail_json              jsonb                       NOT NULL DEFAULT '{}',
+    sidecar_scores_json         jsonb                       NOT NULL DEFAULT '{}',
+    personalization_enabled     boolean                     NOT NULL DEFAULT true,
+    sidecar_scoring_enabled     boolean                     NOT NULL DEFAULT true,
+    last_calculated_at          timestamp with time zone,
+    created_at                  timestamp with time zone    NOT NULL,
+    updated_at                  timestamp with time zone    NOT NULL,
+    CONSTRAINT pk_player_mind_profiles PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_player_mind_profiles_player_id
+    ON player_mind_profiles (player_id);
+CREATE INDEX IF NOT EXISTS ix_player_mind_profiles_archetype
+    ON player_mind_profiles (archetype);
+CREATE INDEX IF NOT EXISTS ix_player_mind_profiles_churn_risk
+    ON player_mind_profiles (churn_risk_score);
+CREATE INDEX IF NOT EXISTS ix_player_mind_profiles_frustration_risk
+    ON player_mind_profiles (frustration_risk_score);
+CREATE INDEX IF NOT EXISTS ix_player_mind_profiles_updated_at
+    ON player_mind_profiles (updated_at);
+
+CREATE TABLE IF NOT EXISTS player_behavior_events (
+    id            uuid                        NOT NULL,
+    player_id     uuid                        NOT NULL,
+    event_type    character varying(128)      NOT NULL,
+    event_source  character varying(128)      NOT NULL,
+    category      character varying(128),
+    difficulty    character varying(64),
+    mode          character varying(64),
+    metadata_json jsonb                       NOT NULL DEFAULT '{}',
+    occurred_at   timestamp with time zone    NOT NULL,
+    ingested_at   timestamp with time zone    NOT NULL,
+    CONSTRAINT pk_player_behavior_events PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_player_behavior_events_player_time
+    ON player_behavior_events (player_id, occurred_at);
+CREATE INDEX IF NOT EXISTS ix_player_behavior_events_type
+    ON player_behavior_events (event_type);
+CREATE INDEX IF NOT EXISTS ix_player_behavior_events_source
+    ON player_behavior_events (event_source);
+CREATE INDEX IF NOT EXISTS ix_player_behavior_events_category
+    ON player_behavior_events (category);
+
+CREATE TABLE IF NOT EXISTS personalization_recommendations (
+    id                  uuid                        NOT NULL,
+    player_id           uuid                        NOT NULL,
+    recommendation_type character varying(128)      NOT NULL,
+    source              character varying(64)       NOT NULL DEFAULT 'backend',
+    priority            integer                     NOT NULL DEFAULT 0,
+    score               numeric(5,2)                NOT NULL DEFAULT 0.50,
+    payload_json        jsonb                       NOT NULL DEFAULT '{}',
+    guardrail_json      jsonb                       NOT NULL DEFAULT '{}',
+    expires_at          timestamp with time zone,
+    accepted_at         timestamp with time zone,
+    dismissed_at        timestamp with time zone,
+    created_at          timestamp with time zone    NOT NULL,
+    CONSTRAINT pk_personalization_recommendations PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_personalization_recommendations_player_created
+    ON personalization_recommendations (player_id, created_at);
+CREATE INDEX IF NOT EXISTS ix_personalization_recommendations_type
+    ON personalization_recommendations (recommendation_type);
+
+CREATE TABLE IF NOT EXISTS personalization_rules (
+    id          uuid                        NOT NULL,
+    rule_key    character varying(256)      NOT NULL,
+    description character varying(512)      NOT NULL DEFAULT '',
+    is_enabled  boolean                     NOT NULL DEFAULT true,
+    rule_json   jsonb                       NOT NULL DEFAULT '{}',
+    created_at  timestamp with time zone    NOT NULL,
+    updated_at  timestamp with time zone    NOT NULL,
+    CONSTRAINT pk_personalization_rules PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ix_personalization_rules_rule_key
+    ON personalization_rules (rule_key);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260429100000_AddPersonalizationTables', '10.0.7')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- 8. 20260429120000_AddExperimentTables
+--    Creates experiments, experiment_variants, and experiment_assignments
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS experiments (
+    id                 uuid                        NOT NULL,
+    key                character varying(128)      NOT NULL,
+    name               character varying(256)      NOT NULL,
+    description        character varying(1000),
+    status             character varying(32)       NOT NULL DEFAULT 'draft',
+    allocation_percent numeric(5,2)                NOT NULL DEFAULT 100,
+    starts_at          timestamp with time zone,
+    ends_at            timestamp with time zone,
+    metadata_json      jsonb                       NOT NULL DEFAULT '{}',
+    created_at         timestamp with time zone    NOT NULL,
+    updated_at         timestamp with time zone    NOT NULL,
+    CONSTRAINT "PK_experiments" PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_experiments_key"
+    ON experiments (key);
+CREATE INDEX IF NOT EXISTS "IX_experiments_status"
+    ON experiments (status);
+
+CREATE TABLE IF NOT EXISTS experiment_variants (
+    id            uuid                        NOT NULL,
+    experiment_id uuid                        NOT NULL,
+    key           character varying(128)      NOT NULL,
+    name          character varying(256)      NOT NULL,
+    weight        numeric(6,2)                NOT NULL DEFAULT 50,
+    is_control    boolean                     NOT NULL DEFAULT false,
+    config_json   jsonb                       NOT NULL DEFAULT '{}',
+    CONSTRAINT "PK_experiment_variants" PRIMARY KEY (id),
+    CONSTRAINT "FK_experiment_variants_experiments_experiment_id"
+        FOREIGN KEY (experiment_id) REFERENCES experiments (id) ON DELETE CASCADE
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_experiment_variants_experiment_id_key"
+    ON experiment_variants (experiment_id, key);
+
+CREATE TABLE IF NOT EXISTS experiment_assignments (
+    id               uuid                        NOT NULL,
+    player_id        uuid                        NOT NULL,
+    experiment_id    uuid                        NOT NULL,
+    experiment_key   character varying(128)      NOT NULL,
+    variant_key      character varying(128)      NOT NULL,
+    assigned_at      timestamp with time zone    NOT NULL,
+    first_seen_at    timestamp with time zone,
+    impression_count integer                     NOT NULL DEFAULT 0,
+    outcome_count    integer                     NOT NULL DEFAULT 0,
+    outcome_json     jsonb                       NOT NULL DEFAULT '{}',
+    CONSTRAINT "PK_experiment_assignments" PRIMARY KEY (id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "IX_experiment_assignments_player_id_experiment_id"
+    ON experiment_assignments (player_id, experiment_id);
+CREATE INDEX IF NOT EXISTS "IX_experiment_assignments_experiment_id_variant_key"
+    ON experiment_assignments (experiment_id, variant_key);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260429120000_AddExperimentTables', '10.0.7')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- 9. 20260430120000_AddPersonalizationAuditLog
+--    Creates personalization_audit_logs with full JSONB decision trace
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS personalization_audit_logs (
+    id                      uuid                        NOT NULL,
+    player_id               uuid                        NOT NULL,
+    recommendation_id       uuid,
+    decision_type           character varying(128)      NOT NULL,
+    source                  character varying(64)       NOT NULL DEFAULT 'backend',
+    reason                  character varying(512)      NOT NULL DEFAULT '',
+    input_signals_json      jsonb                       NOT NULL DEFAULT '{}',
+    candidate_json          jsonb                       NOT NULL DEFAULT '{}',
+    guardrails_applied_json jsonb                       NOT NULL DEFAULT '{}',
+    final_decision_json     jsonb                       NOT NULL DEFAULT '{}',
+    created_at              timestamp with time zone    NOT NULL,
+    CONSTRAINT pk_personalization_audit_logs PRIMARY KEY (id)
+);
+
+CREATE INDEX IF NOT EXISTS ix_personalization_audit_logs_player_created
+    ON personalization_audit_logs (player_id, created_at);
+CREATE INDEX IF NOT EXISTS ix_personalization_audit_logs_decision_type
+    ON personalization_audit_logs (decision_type);
+CREATE INDEX IF NOT EXISTS ix_personalization_audit_logs_recommendation_id
+    ON personalization_audit_logs (recommendation_id);
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260430120000_AddPersonalizationAuditLog', '10.0.7')
+ON CONFLICT DO NOTHING;
+
+-- =============================================================================
+-- 10. 20260501090000_AddReasonToPersonalizationRecommendation
+--     Adds reason column (explainability text) to personalization_recommendations
+-- =============================================================================
+
+ALTER TABLE personalization_recommendations
+    ADD COLUMN IF NOT EXISTS reason character varying(512) NOT NULL DEFAULT '';
+
+INSERT INTO "__EFMigrationsHistory" ("MigrationId", "ProductVersion")
+VALUES ('20260501090000_AddReasonToPersonalizationRecommendation', '10.0.7')
 ON CONFLICT DO NOTHING;
 
 -- =============================================================================
 -- Done. Verify with:
 --   SELECT "MigrationId" FROM "__EFMigrationsHistory" ORDER BY "MigrationId";
--- Expected last row: 20260426110000_AddEffectiveMaxQuantity
+-- Expected last row: 20260501090000_AddReasonToPersonalizationRecommendation
 -- =============================================================================
 
 COMMIT;


### PR DESCRIPTION
SQL script corrections:
- Fix migration ID typo: 20260425120000 → 20260425150120 (AddSeasonRewardRules)
- Fix ProductVersion from 9.0.0 → 9.0.11 for EF Core 9 migrations
- Add 4 missing migrations not present in original script:
  - 20260429100000_AddPersonalizationTables (player_mind_profiles, player_behavior_events, personalization_recommendations, personalization_rules)
  - 20260429120000_AddExperimentTables (experiments, experiment_variants, experiment_assignments)
  - 20260430120000_AddPersonalizationAuditLog (personalization_audit_logs)
  - 20260501090000_AddReasonToPersonalizationRecommendation (reason column)
- Use ProductVersion 10.0.7 for EF Core 10 migrations

Docker fix:
- Replace addgroup/adduser (Alpine) with groupadd/useradd (Debian) in Dockerfile.api and Dockerfile.migrate — aspnet:10.0 is Debian 12 based and the adduser package is not present in the minimal runtime image

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2