### PR TITLE
Fix PendingModelChangesWarning in design-time DbContext factory

### DIFF
--- a/Tycoon.Backend.Migrations/AppDbDesignTimeFactory.cs
+++ b/Tycoon.Backend.Migrations/AppDbDesignTimeFactory.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.EntityFrameworkCore.Diagnostics;
 using Microsoft.Extensions.Configuration;
 using Tycoon.Backend.Infrastructure.Persistence;
 
@@ -31,6 +32,7 @@ public sealed class AppDbDesignTimeFactory : IDesignTimeDbContextFactory<AppDb>
         var options = new DbContextOptionsBuilder<AppDb>()
             .UseNpgsql(cs)
             .UseSnakeCaseNamingConvention()
+            .ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning))
             .Options;
 
         return new AppDb(options);


### PR DESCRIPTION
The warning suppression was already present in the production DI path (DependencyInjection.cs) but the design-time factory used by 'dotnet ef database update' builds DbContextOptions independently, bypassing AddDbContext entirely.

Added the same ConfigureWarnings(w => w.Ignore(PendingModelChangesWarning)) to AppDbDesignTimeFactory so 'dotnet ef database update' no longer throws InvalidOperationException during migration runs.

Root cause: hand-written migrations lack Designer.cs snapshots, causing EF's model-vs-snapshot diff to flag false positives. The snapshot was updated separately; this suppression covers any residual diff from UseSnakeCaseNamingConvention() design-time vs runtime naming resolution.

https://claude.ai/code/session_01SPrvixS47Aq7DaETCA12g2