### PR TITLE
Fix CS1503: pass Oid object to ECCurve.CreateFromOid

### DIFF
--- a/Synaptix.Security.Kms.Application/Sessions/SecureSessionService.cs
+++ b/Synaptix.Security.Kms.Application/Sessions/SecureSessionService.cs
@@ -12,7 +12,7 @@ public sealed class SecureSessionService(ISessionStore store) : ISecureSessionSe
     private static readonly TimeSpan SessionTtl = TimeSpan.FromMinutes(30);
 
     // X25519 OID — supported on .NET 8+ Linux/macOS/Windows via CNG
-    private static readonly ECCurve Curve25519 = ECCurve.CreateFromOid("1.3.101.110");
+    private static readonly ECCurve Curve25519 = ECCurve.CreateFromOid(new Oid("1.3.101.110"));
 
     public async Task<StartSessionResult> StartAsync(
         string subjectId, StartSessionCommand command, CancellationToken ct)


### PR DESCRIPTION
ECCurve.CreateFromOid expects System.Security.Cryptography.Oid, not a raw string. Wrap the OID value with new Oid("1.3.101.110").

https://claude.ai/code/session_01CA3D8ByPhDhEjE56dRHNGM