### PR TITLE
Fix CS1061: add Caching.Memory package, drop ValidateDataAnnotations

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -98,6 +98,7 @@
   </ItemGroup>
   <ItemGroup Label="Microsoft Extensions">
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="10.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration" Version="10.0.7" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.7" />

--- a/Synaptix.Security.Kms.Infrastructure/DependencyInjection.cs
+++ b/Synaptix.Security.Kms.Infrastructure/DependencyInjection.cs
@@ -36,7 +36,6 @@ public static class DependencyInjection
         {
             services.AddOptions<VaultOptions>()
                 .Bind(vaultSection)
-                .ValidateDataAnnotations()
                 .ValidateOnStart();
 
             services.AddHttpClient<VaultTransitClient>((sp, client) =>

--- a/Synaptix.Security.Kms.Infrastructure/Synaptix.Security.Kms.Infrastructure.csproj
+++ b/Synaptix.Security.Kms.Infrastructure/Synaptix.Security.Kms.Infrastructure.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" />
     <PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
     <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" />


### PR DESCRIPTION
- Directory.Packages.props: add Microsoft.Extensions.Caching.Memory 10.0.7 so AddDistributedMemoryCache() resolves in the Infrastructure project
- Infrastructure.csproj: reference the new package explicitly
- DependencyInjection.cs: remove ValidateDataAnnotations() — VaultOptions uses required properties (compile-time enforcement), not annotation attributes, so the call was both unnecessary and missing a package dep

https://claude.ai/code/session_01CA3D8ByPhDhEjE56dRHNGM