### PR TITLE
fix(kms-api): make Docker container start and /health respond

### DIFF
--- a/Synaptix.Security.Kms.Api/Dockerfile
+++ b/Synaptix.Security.Kms.Api/Dockerfile
@@ -1,4 +1,7 @@
 FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS base
+# curl is needed for the compose healthcheck; not present in the slim aspnet image
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
 USER $APP_UID
 WORKDIR /app
 EXPOSE 5050

--- a/Synaptix.Security.Kms.Api/Program.cs
+++ b/Synaptix.Security.Kms.Api/Program.cs
@@ -96,6 +96,14 @@ try
     app.UseAuthentication();
     app.UseAuthorization();
 
+    // ── Health — always available regardless of environment ───────────────────
+    app.MapHealthChecks("/health");
+    app.MapHealthChecks("/alive", new Microsoft.AspNetCore.Diagnostics.HealthChecks.HealthCheckOptions
+    {
+        Predicate = r => r.Tags.Contains("live")
+    });
+
+    // ── OpenAPI — dev only ────────────────────────────────────────────────────
     if (app.Environment.IsDevelopment())
         app.MapOpenApi();
 
@@ -105,7 +113,6 @@ try
     KeyEndpoints.Map(app);
     InternalEndpoints.Map(app);
 
-    app.MapDefaultEndpoints();
     app.MapGet("/", () => new { service = "Synaptix.Security.Kms", version = "1.0" });
 
     await app.RunAsync();

--- a/Synaptix.Security.Kms.Api/Properties/launchSettings.json
+++ b/Synaptix.Security.Kms.Api/Properties/launchSettings.json
@@ -1,10 +1,21 @@
 {
   "profiles": {
     "Synaptix.Security.Kms.Api": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "applicationUrl": "http://localhost:5050",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
     },
     "Container (Dockerfile)": {
-      "commandName": "Docker"
+      "commandName": "Docker",
+      "launchBrowser": false,
+      "launchUrl": "{Scheme}://{ServiceHost}:{ServicePort}/health",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "publishAllPorts": true,
+      "useSSL": false
     }
   }
 }

--- a/Synaptix.Security.Kms.Api/appsettings.Development.json
+++ b/Synaptix.Security.Kms.Api/appsettings.Development.json
@@ -28,6 +28,6 @@
     "Required": false
   },
   "ConnectionStrings": {
-    "cache": "localhost:6379"
+    "cache": ""
   }
 }


### PR DESCRIPTION
Four blockers fixed so `docker compose -f docker/compose.security.yml up` passes the curl healthcheck and the container reaches healthy state:

1. Dockerfile: install curl in the runtime image (aspnet slim has none)
2. Program.cs: map /health and /alive unconditionally (not only in dev); remove MapDefaultEndpoints() which gated health behind IsDevelopment
3. launchSettings.json: add applicationUrl + ASPNETCORE_ENVIRONMENT so `dotnet run` binds to port 5050 instead of a random port
4. appsettings.Development.json: clear Redis connection string so the in-memory cache fallback is used when Redis is not present locally

https://claude.ai/code/session_01CA3D8ByPhDhEjE56dRHNGM