### PR TITLE
fix(docker): disable Vault mlock so container starts without CAP_SETFCAP

### DIFF
--- a/docker/compose.security.yml
+++ b/docker/compose.security.yml
@@ -39,8 +39,7 @@ services:
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "${VAULT_DEV_TOKEN:-dev-root-token-change-me}"
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
-    cap_add:
-      - IPC_LOCK
+      VAULT_DISABLE_MLOCK: "true"
     command: server -dev
     networks: [security-net]
     healthcheck:


### PR DESCRIPTION
Container runtimes that don't grant CAP_SETFCAP cause Vault to exit with "unable to set CAP_SETFCAP effective capability". Setting VAULT_DISABLE_MLOCK bypasses the mlock syscall (acceptable in dev mode — secrets are in-memory only anyway) and removes the cap_add that triggered the capability request.

https://claude.ai/code/session_01CA3D8ByPhDhEjE56dRHNGM