### PR TITLE
fix(docker): pin Vault to 1.17 to avoid CAP_SETFCAP crash on latest

### DIFF
--- a/docker/compose.security.yml
+++ b/docker/compose.security.yml
@@ -30,8 +30,12 @@ services:
   # WARNING: dev mode is in-memory only and resets on restart.
   # For staging/prod use an initialized + unsealed Vault with
   # persistent storage — see docs/Synaptix_Backend_Security_KMS_Handoff.md
+  #
+  # Pinned to 1.17 — hashicorp/vault:latest (1.18+) attempts to acquire
+  # CAP_SETFCAP before config is loaded, which fails in restricted container
+  # runtimes regardless of VAULT_DISABLE_MLOCK / VAULT_LOCAL_CONFIG.
   vault:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.17
     container_name: synaptix_vault
     restart: unless-stopped
     ports:
@@ -40,10 +44,6 @@ services:
       VAULT_DEV_ROOT_TOKEN_ID: "${VAULT_DEV_TOKEN:-dev-root-token-change-me}"
       VAULT_DEV_LISTEN_ADDRESS: "0.0.0.0:8200"
       VAULT_DISABLE_MLOCK: "1"
-      # VAULT_LOCAL_CONFIG is written to a config file by the entrypoint
-      # before the Vault binary starts — this is the only reliable way to
-      # disable mlock in newer Vault images where the binary acquires
-      # CAP_SETFCAP before reading VAULT_DISABLE_MLOCK from the environment.
       VAULT_LOCAL_CONFIG: '{"disable_mlock":true}'
     command: server -dev
     networks: [security-net]
@@ -58,7 +58,7 @@ services:
   # Vault Init (one-shot transit setup)
   # ================================
   vault-init:
-    image: hashicorp/vault:latest
+    image: hashicorp/vault:1.17
     container_name: synaptix_vault_init
     restart: "no"
     environment:


### PR DESCRIPTION
hashicorp/vault:latest (1.18+) acquires CAP_SETFCAP before loading any config, so VAULT_DISABLE_MLOCK and VAULT_LOCAL_CONFIG are ignored and the container exits with "unable to set CAP_SETFCAP effective capability". Vault 1.17 reads disable_mlock from config before any capability setup, making both VAULT_DISABLE_MLOCK=1 and VAULT_LOCAL_CONFIG effective. Pinned vault-init to the same version for consistency.

https://claude.ai/code/session_01CA3D8ByPhDhEjE56dRHNGM